### PR TITLE
bundlers userop receipt types compatibility

### DIFF
--- a/src/actions/bundler/getUserOperationReceipt.ts
+++ b/src/actions/bundler/getUserOperationReceipt.ts
@@ -8,7 +8,7 @@ import type {
     Transport
 } from "viem"
 import type { BundlerClient } from "../../clients/createBundlerClient.js"
-import type { BundlerRpcSchema, BigNumber } from "../../types/bundler.js"
+import type { BigNumber, BundlerRpcSchema } from "../../types/bundler.js"
 import type { TStatus } from "../../types/userOperation.js"
 import { transactionReceiptStatus } from "../../utils/deepHexlify.js"
 
@@ -102,12 +102,25 @@ export const getUserOperationReceipt = async <
             blockNumber: BigInt(response.receipt.blockNumber),
             from: response.receipt.from,
             to: response.receipt.to,
-            cumulativeGasUsed: (typeof response.receipt.cumulativeGasUsed) === "object" ? BigInt((response.receipt.cumulativeGasUsed as BigNumber)._hex) : BigInt(response.receipt.cumulativeGasUsed as Hex),
+            cumulativeGasUsed:
+                typeof response.receipt.cumulativeGasUsed === "object"
+                    ? BigInt(
+                          (response.receipt.cumulativeGasUsed as BigNumber)._hex
+                      )
+                    : BigInt(response.receipt.cumulativeGasUsed as Hex),
             status: transactionReceiptStatus[response.receipt.status],
-            gasUsed: (typeof response.receipt.gasUsed) === "object" ? BigInt((response.receipt.gasUsed as BigNumber)._hex) : BigInt(response.receipt.gasUsed as Hex),
+            gasUsed:
+                typeof response.receipt.gasUsed === "object"
+                    ? BigInt((response.receipt.gasUsed as BigNumber)._hex)
+                    : BigInt(response.receipt.gasUsed as Hex),
             contractAddress: response.receipt.contractAddress,
             logsBloom: response.receipt.logsBloom,
-            effectiveGasPrice: (typeof response.receipt.effectiveGasPrice) === "object" ? BigInt((response.receipt.effectiveGasPrice as BigNumber)._hex) : BigInt(response.receipt.effectiveGasPrice as Hex),
+            effectiveGasPrice:
+                typeof response.receipt.effectiveGasPrice === "object"
+                    ? BigInt(
+                          (response.receipt.effectiveGasPrice as BigNumber)._hex
+                      )
+                    : BigInt(response.receipt.effectiveGasPrice as Hex)
         },
         logs: response.logs.map((log) => ({
             data: log.data,

--- a/src/actions/bundler/getUserOperationReceipt.ts
+++ b/src/actions/bundler/getUserOperationReceipt.ts
@@ -8,7 +8,7 @@ import type {
     Transport
 } from "viem"
 import type { BundlerClient } from "../../clients/createBundlerClient.js"
-import type { BundlerRpcSchema } from "../../types/bundler.js"
+import type { BundlerRpcSchema, BigNumber } from "../../types/bundler.js"
 import type { TStatus } from "../../types/userOperation.js"
 import { transactionReceiptStatus } from "../../utils/deepHexlify.js"
 
@@ -30,12 +30,12 @@ export type GetUserOperationReceiptReturnType = {
         blockNumber: bigint
         from: Address
         to: Address | null
-        cumulativeGasUsed: bigint
+        cumulativeGasUsed: bigint | BigNumber
         status: TStatus
-        gasUsed: bigint
+        gasUsed: bigint | BigNumber
         contractAddress: Address | null
         logsBloom: Hex
-        effectiveGasPrice: bigint
+        effectiveGasPrice: bigint | BigNumber
     }
     logs: {
         data: Hex
@@ -102,12 +102,12 @@ export const getUserOperationReceipt = async <
             blockNumber: BigInt(response.receipt.blockNumber),
             from: response.receipt.from,
             to: response.receipt.to,
-            cumulativeGasUsed: BigInt(response.receipt.cumulativeGasUsed),
+            cumulativeGasUsed: (typeof response.receipt.cumulativeGasUsed) === "object" ? BigInt((response.receipt.cumulativeGasUsed as BigNumber)._hex) : BigInt(response.receipt.cumulativeGasUsed as Hex),
             status: transactionReceiptStatus[response.receipt.status],
-            gasUsed: BigInt(response.receipt.gasUsed),
+            gasUsed: (typeof response.receipt.gasUsed) === "object" ? BigInt((response.receipt.gasUsed as BigNumber)._hex) : BigInt(response.receipt.gasUsed as Hex),
             contractAddress: response.receipt.contractAddress,
             logsBloom: response.receipt.logsBloom,
-            effectiveGasPrice: BigInt(response.receipt.effectiveGasPrice)
+            effectiveGasPrice: (typeof response.receipt.effectiveGasPrice) === "object" ? BigInt((response.receipt.effectiveGasPrice as BigNumber)._hex) : BigInt(response.receipt.effectiveGasPrice as Hex),
         },
         logs: response.logs.map((log) => ({
             data: log.data,

--- a/src/types/bundler.ts
+++ b/src/types/bundler.ts
@@ -2,6 +2,11 @@ import type { Address, Hash, Hex } from "viem"
 import type { PartialBy } from "viem/types/utils"
 import type { UserOperationWithBigIntAsHex } from "./userOperation.js"
 
+export type BigNumber = {
+    _hex: Hex
+    _isBigNumber: boolean
+}
+
 export type BundlerRpcSchema = [
     {
         Method: "eth_sendUserOperation"
@@ -68,12 +73,12 @@ type UserOperationReceiptWithBigIntAsHex = {
         blockNumber: Hex
         from: Address
         to: Address | null
-        cumulativeGasUsed: Hex
+        cumulativeGasUsed: Hex | BigNumber
         status: "0x0" | "0x1"
-        gasUsed: Hex
+        gasUsed: Hex | BigNumber
         contractAddress: Address | null
         logsBloom: Hex
-        effectiveGasPrice: Hex
+        effectiveGasPrice: Hex | BigNumber
     }
     logs: {
         data: Hex


### PR DESCRIPTION
I used different bundler host and if a bundler is using ethers to get receipts for transaction they have sent (to serve as result of eth_getUserOperationReceipt) current BigInt conversion throws below error

` SyntaxError: Failed to Parse String to BigInt`
 
 since in ERC specs receipt is Only expected to be an object but no further types of receipt object, I have made this changes to allow more types in receipt fields.
 
 https://eips.ethereum.org/EIPS/eip-4337#:~:text=receipt%20the%20TransactionReceipt%20object.%20Note%20that%20the%20returned%20TransactionReceipt%20is%20for%20the%20entire%20bundle%2C%20not%20only%20for%20this%20UserOperation. 
 