### PR TITLE
getSenderAddress fix for ganache provider

### DIFF
--- a/.changeset/itchy-cows-think.md
+++ b/.changeset/itchy-cows-think.md
@@ -1,0 +1,5 @@
+---
+"permissionless": patch
+---
+
+Added ganache support for getSenderAddress

--- a/packages/permissionless/actions/public/getSenderAddress.ts
+++ b/packages/permissionless/actions/public/getSenderAddress.ts
@@ -173,6 +173,30 @@ export const getSenderAddress = async <
                 })
 
                 return error.args[0] as Address
+            } else if (callExecutionError.cause.name === "InvalidInputRpcError") {
+                //Ganache local testing returns "InvalidInputRpcError" with data in regular format
+                const revertError = callExecutionError.cause as RpcRequestErrorType;
+                // biome-ignore lint/suspicious/noExplicitAny: fuse issues
+                const data = (revertError as unknown as any).cause.data;
+
+                const error = decodeErrorResult({
+                    abi: [
+                        {
+                            inputs: [
+                                {
+                                    internalType: "address",
+                                    name: "sender",
+                                    type: "address",
+                                },
+                            ],
+                            name: "SenderAddressResult",
+                            type: "error",
+                        },
+                    ],
+                    data,
+                });
+
+                return error.args[0] as Address;
             }
         }
 

--- a/packages/permissionless/actions/public/getSenderAddress.ts
+++ b/packages/permissionless/actions/public/getSenderAddress.ts
@@ -173,7 +173,9 @@ export const getSenderAddress = async <
                 })
 
                 return error.args[0] as Address
-            } else if (callExecutionError.cause.name === "InvalidInputRpcError") {
+            } 
+            
+            if (callExecutionError.cause.name === "InvalidInputRpcError") {
                 //Ganache local testing returns "InvalidInputRpcError" with data in regular format
                 const revertError = callExecutionError.cause as RpcRequestErrorType;
                 // biome-ignore lint/suspicious/noExplicitAny: fuse issues


### PR DESCRIPTION
I was writing unit tests to simply get an smart account address. I used `ganache@^7.9.2` as my local blockchain (it creates an EIP1193 provider that runs the chain in JS) as it is much simple then having to run something like anvil in a test suite. 

Unfortunately, it seems that the errors it throws are non-standard. Instead of `RpcRequestError` it throws `InvalidInputRpcError`, and the data is encoded as is. This patch fixes this, making it possible to use `getSenderAddress` with ganache (assuming you have the EntryPoint & Smart Account Factory deployed).

https://www.npmjs.com/package/ganache