### PR TITLE
fallback to client account

### DIFF
--- a/packages/permissionless/clients/createSmartAccountClient.ts
+++ b/packages/permissionless/clients/createSmartAccountClient.ts
@@ -137,6 +137,7 @@ export function createSmartAccountClient(
     const client = createBundlerClient({
         ...parameters,
         chain: parameters.chain ?? client_?.chain,
+        account: parameters.account ?? client_?.account,
         key,
         name,
         transport: bundlerTransport,


### PR DESCRIPTION
I am providing a client to `createSmartAccountClient` that is already "bound" to an account, so it would be nice to fallback to this value.

<img width="391" alt="image" src="https://github.com/user-attachments/assets/bf3b416e-24da-4ebb-97cf-bb4c18eb1e64">

