### PR TITLE
Removing extensions on imports

### DIFF
--- a/packages/permissionless/accounts/biconomy/toBiconomySmartAccount.ts
+++ b/packages/permissionless/accounts/biconomy/toBiconomySmartAccount.ts
@@ -29,9 +29,9 @@ import {
     toSmartAccount
 } from "viem/account-abstraction"
 import { signMessage } from "viem/actions"
-import { getAccountNonce } from "../../actions/public/getAccountNonce.js"
-import { type EthereumProvider, toOwner } from "../../utils/toOwner.js"
-import { BiconomyAbi, FactoryAbi } from "./abi/BiconomySmartAccountAbi.js"
+import { getAccountNonce } from "../../actions/public/getAccountNonce"
+import { type EthereumProvider, toOwner } from "../../utils/toOwner"
+import { BiconomyAbi, FactoryAbi } from "./abi/BiconomySmartAccountAbi"
 
 const BICONOMY_PROXY_CREATION_CODE =
     "0x6080346100aa57601f61012038819003918201601f19168301916001600160401b038311848410176100af578084926020946040528339810103126100aa57516001600160a01b0381168082036100aa5715610065573055604051605a90816100c68239f35b60405162461bcd60e51b815260206004820152601e60248201527f496e76616c696420696d706c656d656e746174696f6e206164647265737300006044820152606490fd5b600080fd5b634e487b7160e01b600052604160045260246000fdfe608060405230546000808092368280378136915af43d82803e156020573d90f35b3d90fdfea2646970667358221220a03b18dce0be0b4c9afe58a9eb85c35205e2cf087da098bbf1d23945bf89496064736f6c63430008110033"

--- a/packages/permissionless/accounts/etherspot/toEtherspotSmartAccount.ts
+++ b/packages/permissionless/accounts/etherspot/toEtherspotSmartAccount.ts
@@ -27,17 +27,17 @@ import {
 } from "viem/account-abstraction"
 import { getChainId } from "viem/actions"
 import { getAction } from "viem/utils"
-import { getAccountNonce } from "../../actions/public/getAccountNonce.js"
-import { getSenderAddress } from "../../actions/public/getSenderAddress.js"
-import { encode7579Calls } from "../../utils/encode7579Calls.js"
-import { toOwner } from "../../utils/index.js"
+import { getAccountNonce } from "../../actions/public/getAccountNonce"
+import { getSenderAddress } from "../../actions/public/getSenderAddress"
+import { encode7579Calls } from "../../utils/encode7579Calls"
+import { toOwner } from "../../utils/index"
 import {
     DEFAULT_CONTRACT_ADDRESS,
     DUMMY_ECDSA_SIGNATURE,
     type NetworkAddresses
-} from "./constants.js"
-import { getInitMSAData } from "./utils/getInitMSAData.js"
-import { getNonceKeyWithEncoding } from "./utils/getNonceKey.js"
+} from "./constants"
+import { getInitMSAData } from "./utils/getInitMSAData"
+import { getNonceKeyWithEncoding } from "./utils/getNonceKey"
 
 /**
  * The account creation ABI for a modular etherspot smart account

--- a/packages/permissionless/accounts/etherspot/utils/getInitMSAData.ts
+++ b/packages/permissionless/accounts/etherspot/utils/getInitMSAData.ts
@@ -2,7 +2,7 @@ import { type Address, encodeFunctionData, zeroAddress } from "viem"
 import {
     EtherspotBootstrapAbi,
     EtherspotOnInstallAbi
-} from "../abi/EtherspotBootstrapAbi.js"
+} from "../abi/EtherspotBootstrapAbi"
 
 export const getInitMSAData = (ecdsaValidatorAddress: Address) => {
     const validators = makeBootstrapConfig(ecdsaValidatorAddress, "0x")

--- a/packages/permissionless/accounts/etherspot/utils/getNonceKey.ts
+++ b/packages/permissionless/accounts/etherspot/utils/getNonceKey.ts
@@ -1,5 +1,5 @@
 import { type Address, concatHex, pad, toHex } from "viem"
-import { VALIDATOR_MODE, VALIDATOR_TYPE } from "../constants.js"
+import { VALIDATOR_MODE, VALIDATOR_TYPE } from "../constants"
 
 export const getNonceKeyWithEncoding = (
     validatorAddress: Address,

--- a/packages/permissionless/accounts/index.ts
+++ b/packages/permissionless/accounts/index.ts
@@ -3,7 +3,7 @@ import {
     type ToSimpleSmartAccountParameters,
     type ToSimpleSmartAccountReturnType,
     toSimpleSmartAccount
-} from "./simple/toSimpleSmartAccount.js"
+} from "./simple/toSimpleSmartAccount"
 
 import {
     type LightAccountVersion,
@@ -11,21 +11,21 @@ import {
     type ToLightSmartAccountParameters,
     type ToLightSmartAccountReturnType,
     toLightSmartAccount
-} from "./light/toLightSmartAccount.js"
+} from "./light/toLightSmartAccount"
 
 import {
     type ToTrustSmartAccountParameters,
     type ToTrustSmartAccountReturnType,
     type TrustSmartAccountImplementation,
     toTrustSmartAccount
-} from "./trust/toTrustSmartAccount.js"
+} from "./trust/toTrustSmartAccount"
 
 import {
     type EtherspotSmartAccountImplementation,
     type ToEtherspotSmartAccountParameters,
     type ToEtherspotSmartAccountReturnType,
     toEtherspotSmartAccount
-} from "./etherspot/toEtherspotSmartAccount.js"
+} from "./etherspot/toEtherspotSmartAccount"
 
 import {
     type SafeSmartAccountImplementation,
@@ -33,14 +33,14 @@ import {
     type ToSafeSmartAccountParameters,
     type ToSafeSmartAccountReturnType,
     toSafeSmartAccount
-} from "./safe/toSafeSmartAccount.js"
+} from "./safe/toSafeSmartAccount"
 
 import {
     type EcdsaKernelSmartAccountImplementation,
     type ToEcdsaKernelSmartAccountParameters,
     type ToEcdsaKernelSmartAccountReturnType,
     toEcdsaKernelSmartAccount
-} from "./kernel/toEcdsaKernelSmartAccount.js"
+} from "./kernel/toEcdsaKernelSmartAccount"
 
 import {
     type KernelSmartAccountImplementation,
@@ -48,28 +48,28 @@ import {
     type ToKernelSmartAccountParameters,
     type ToKernelSmartAccountReturnType,
     toKernelSmartAccount
-} from "./kernel/toKernelSmartAccount.js"
+} from "./kernel/toKernelSmartAccount"
 
 import {
     type BiconomySmartAccountImplementation,
     type ToBiconomySmartAccountParameters,
     type ToBiconomySmartAccountReturnType,
     toBiconomySmartAccount
-} from "./biconomy/toBiconomySmartAccount.js"
+} from "./biconomy/toBiconomySmartAccount"
 
 import {
     type NexusSmartAccountImplementation,
     type ToNexusSmartAccountParameters,
     type ToNexusSmartAccountReturnType,
     toNexusSmartAccount
-} from "./nexus/toNexusSmartAccount.js"
+} from "./nexus/toNexusSmartAccount"
 
 import {
     type ThirdwebSmartAccountImplementation,
     type ToThirdwebSmartAccountParameters,
     type ToThirdwebSmartAccountReturnType,
     toThirdwebSmartAccount
-} from "./thirdweb/toThirdwebSmartAccount.js"
+} from "./thirdweb/toThirdwebSmartAccount"
 
 export {
     type ToSimpleSmartAccountParameters,

--- a/packages/permissionless/accounts/kernel/toEcdsaKernelSmartAccount.ts
+++ b/packages/permissionless/accounts/kernel/toEcdsaKernelSmartAccount.ts
@@ -7,14 +7,14 @@ import type {
     Transport,
     WalletClient
 } from "viem"
-import type { EthereumProvider } from "../../utils/toOwner.js"
+import type { EthereumProvider } from "../../utils/toOwner"
 import {
     type KernelSmartAccountImplementation,
     type KernelVersion,
     type ToKernelSmartAccountParameters,
     type ToKernelSmartAccountReturnType,
     toKernelSmartAccount
-} from "./toKernelSmartAccount.js"
+} from "./toKernelSmartAccount"
 
 export type ToEcdsaKernelSmartAccountParameters<
     entryPointVersion extends "0.6" | "0.7",

--- a/packages/permissionless/accounts/kernel/toKernelSmartAccount.ts
+++ b/packages/permissionless/accounts/kernel/toKernelSmartAccount.ts
@@ -33,26 +33,26 @@ import {
 import { signMessage as _signMessage, getChainId } from "viem/actions"
 import { getAction } from "viem/utils"
 import { base64UrlToBytes, bytesToHex, parsePublicKey } from "webauthn-p256"
-import { getAccountNonce } from "../../actions/public/getAccountNonce.js"
-import { getSenderAddress } from "../../actions/public/getSenderAddress.js"
-import { type EthereumProvider, toOwner } from "../../utils/toOwner.js"
-import { KernelInitAbi } from "./abi/KernelAccountAbi.js"
+import { getAccountNonce } from "../../actions/public/getAccountNonce"
+import { getSenderAddress } from "../../actions/public/getSenderAddress"
+import { type EthereumProvider, toOwner } from "../../utils/toOwner"
+import { KernelInitAbi } from "./abi/KernelAccountAbi"
 import {
     KernelV3InitAbi,
     KernelV3_1AccountAbi
-} from "./abi/KernelV3AccountAbi.js"
-import { KernelV3MetaFactoryDeployWithFactoryAbi } from "./abi/KernelV3MetaFactoryAbi.js"
+} from "./abi/KernelV3AccountAbi"
+import { KernelV3MetaFactoryDeployWithFactoryAbi } from "./abi/KernelV3MetaFactoryAbi"
 import {
     DUMMY_ECDSA_SIGNATURE,
     ROOT_MODE_KERNEL_V2,
     VALIDATOR_TYPE
-} from "./constants.js"
-import { encodeCallData } from "./utils/encodeCallData.js"
-import { getNonceKeyWithEncoding } from "./utils/getNonceKey.js"
-import { isKernelV2 } from "./utils/isKernelV2.js"
-import { isWebAuthnAccount } from "./utils/isWebAuthnAccount.js"
-import { signMessage } from "./utils/signMessage.js"
-import { signTypedData } from "./utils/signTypedData.js"
+} from "./constants"
+import { encodeCallData } from "./utils/encodeCallData"
+import { getNonceKeyWithEncoding } from "./utils/getNonceKey"
+import { isKernelV2 } from "./utils/isKernelV2"
+import { isWebAuthnAccount } from "./utils/isWebAuthnAccount"
+import { signMessage } from "./utils/signMessage"
+import { signTypedData } from "./utils/signTypedData"
 
 /**
  * The account creation ABI for a kernel smart account (from the KernelFactory)

--- a/packages/permissionless/accounts/kernel/utils/encodeCallData.ts
+++ b/packages/permissionless/accounts/kernel/utils/encodeCallData.ts
@@ -1,8 +1,8 @@
 import { type Address, type Hex, encodeFunctionData } from "viem"
-import { encode7579Calls } from "../../../utils/encode7579Calls.js"
-import { KernelExecuteAbi } from "../abi/KernelAccountAbi.js"
-import type { KernelVersion } from "../toKernelSmartAccount.js"
-import { isKernelV2 } from "./isKernelV2.js"
+import { encode7579Calls } from "../../../utils/encode7579Calls"
+import { KernelExecuteAbi } from "../abi/KernelAccountAbi"
+import type { KernelVersion } from "../toKernelSmartAccount"
+import { isKernelV2 } from "./isKernelV2"
 
 export const encodeCallData = ({
     kernelVersion,

--- a/packages/permissionless/accounts/kernel/utils/getNonceKey.ts
+++ b/packages/permissionless/accounts/kernel/utils/getNonceKey.ts
@@ -1,7 +1,7 @@
 import { type Address, concatHex, maxUint16, pad, toHex } from "viem"
-import { VALIDATOR_MODE, VALIDATOR_TYPE } from "../constants.js"
-import type { KernelVersion } from "../toKernelSmartAccount.js"
-import { isKernelV2 } from "./isKernelV2.js"
+import { VALIDATOR_MODE, VALIDATOR_TYPE } from "../constants"
+import type { KernelVersion } from "../toKernelSmartAccount"
+import { isKernelV2 } from "./isKernelV2"
 
 export const getNonceKeyWithEncoding = (
     kernelVersion: KernelVersion<"0.6" | "0.7">,

--- a/packages/permissionless/accounts/kernel/utils/isKernelV2.ts
+++ b/packages/permissionless/accounts/kernel/utils/isKernelV2.ts
@@ -1,4 +1,4 @@
-import type { KernelVersion } from "../toKernelSmartAccount.js"
+import type { KernelVersion } from "../toKernelSmartAccount"
 
 export const isKernelV2 = (version: KernelVersion<"0.6" | "0.7">): boolean => {
     const regex = /0\.2\.\d+/

--- a/packages/permissionless/accounts/kernel/utils/signMessage.ts
+++ b/packages/permissionless/accounts/kernel/utils/signMessage.ts
@@ -9,11 +9,11 @@ import {
 import type { WebAuthnAccount } from "viem/account-abstraction"
 import { signMessage as _signMessage } from "viem/actions"
 import { parseSignature } from "webauthn-p256"
-import { isWebAuthnAccount } from "./isWebAuthnAccount.js"
+import { isWebAuthnAccount } from "./isWebAuthnAccount"
 import {
     type WrapMessageHashParams,
     wrapMessageHash
-} from "./wrapMessageHash.js"
+} from "./wrapMessageHash"
 
 export async function signMessage({
     message,

--- a/packages/permissionless/accounts/kernel/utils/signTypedData.ts
+++ b/packages/permissionless/accounts/kernel/utils/signTypedData.ts
@@ -7,12 +7,12 @@ import {
     validateTypedData
 } from "viem"
 import type { WebAuthnAccount } from "viem/account-abstraction"
-import { isWebAuthnAccount } from "./isWebAuthnAccount.js"
-import { signMessage } from "./signMessage.js"
+import { isWebAuthnAccount } from "./isWebAuthnAccount"
+import { signMessage } from "./signMessage"
 import {
     type WrapMessageHashParams,
     wrapMessageHash
-} from "./wrapMessageHash.js"
+} from "./wrapMessageHash"
 
 export async function signTypedData(
     parameters: TypedDataDefinition &

--- a/packages/permissionless/accounts/kernel/utils/wrapMessageHash.ts
+++ b/packages/permissionless/accounts/kernel/utils/wrapMessageHash.ts
@@ -6,8 +6,8 @@ import {
     stringToHex
 } from "viem"
 import { type Address, domainSeparator } from "viem"
-import type { KernelVersion } from "../toKernelSmartAccount.js"
-import { isKernelV2 } from "./isKernelV2.js"
+import type { KernelVersion } from "../toKernelSmartAccount"
+import { isKernelV2 } from "./isKernelV2"
 
 export type WrapMessageHashParams = {
     kernelVersion: KernelVersion<"0.6" | "0.7">

--- a/packages/permissionless/accounts/light/toLightSmartAccount.ts
+++ b/packages/permissionless/accounts/light/toLightSmartAccount.ts
@@ -26,9 +26,9 @@ import {
 } from "viem/account-abstraction"
 import { getChainId, signMessage } from "viem/actions"
 import { getAction } from "viem/utils"
-import { getAccountNonce } from "../../actions/public/getAccountNonce.js"
-import { getSenderAddress } from "../../actions/public/getSenderAddress.js"
-import { type EthereumProvider, toOwner } from "../../utils/toOwner.js"
+import { getAccountNonce } from "../../actions/public/getAccountNonce"
+import { getSenderAddress } from "../../actions/public/getSenderAddress"
+import { type EthereumProvider, toOwner } from "../../utils/toOwner"
 
 const getAccountInitCode = async (
     owner: Address,

--- a/packages/permissionless/accounts/nexus/toNexusSmartAccount.ts
+++ b/packages/permissionless/accounts/nexus/toNexusSmartAccount.ts
@@ -37,9 +37,9 @@ import {
 } from "viem/account-abstraction"
 import { getChainId, readContract } from "viem/actions"
 import { getAction } from "viem/utils"
-import { getAccountNonce } from "../../actions/public/getAccountNonce.js"
-import { encode7579Calls } from "../../utils/encode7579Calls.js"
-import { type EthereumProvider, toOwner } from "../../utils/toOwner.js"
+import { getAccountNonce } from "../../actions/public/getAccountNonce"
+import { encode7579Calls } from "../../utils/encode7579Calls"
+import { type EthereumProvider, toOwner } from "../../utils/toOwner"
 
 const wrapMessageHash = (
     messageHash: Hex,

--- a/packages/permissionless/accounts/safe/toSafeSmartAccount.ts
+++ b/packages/permissionless/accounts/safe/toSafeSmartAccount.ts
@@ -38,10 +38,10 @@ import {
 } from "viem/account-abstraction"
 import { getChainId, readContract, signTypedData } from "viem/actions"
 import { getAction } from "viem/utils"
-import { getAccountNonce } from "../../actions/public/getAccountNonce.js"
-import { encode7579Calls } from "../../utils/encode7579Calls.js"
-import { isSmartAccountDeployed } from "../../utils/isSmartAccountDeployed.js"
-import { type EthereumProvider, toOwner } from "../../utils/toOwner.js"
+import { getAccountNonce } from "../../actions/public/getAccountNonce"
+import { encode7579Calls } from "../../utils/encode7579Calls"
+import { isSmartAccountDeployed } from "../../utils/isSmartAccountDeployed"
+import { type EthereumProvider, toOwner } from "../../utils/toOwner"
 
 export type SafeVersion = "1.4.1"
 

--- a/packages/permissionless/accounts/simple/toSimpleSmartAccount.ts
+++ b/packages/permissionless/accounts/simple/toSimpleSmartAccount.ts
@@ -23,9 +23,9 @@ import {
 } from "viem/account-abstraction"
 import { getChainId, signMessage } from "viem/actions"
 import { getAction } from "viem/utils"
-import { getAccountNonce } from "../../actions/public/getAccountNonce.js"
-import { getSenderAddress } from "../../actions/public/getSenderAddress.js"
-import { type EthereumProvider, toOwner } from "../../utils/toOwner.js"
+import { getAccountNonce } from "../../actions/public/getAccountNonce"
+import { getSenderAddress } from "../../actions/public/getSenderAddress"
+import { type EthereumProvider, toOwner } from "../../utils/toOwner"
 
 const getAccountInitCode = async (
     owner: Address,

--- a/packages/permissionless/accounts/thirdweb/toThirdwebSmartAccount.ts
+++ b/packages/permissionless/accounts/thirdweb/toThirdwebSmartAccount.ts
@@ -11,7 +11,7 @@ import type {
     WalletClient
 } from "viem"
 import { getChainId } from "viem/actions"
-import { getAccountNonce } from "../../actions/public/getAccountNonce.js"
+import { getAccountNonce } from "../../actions/public/getAccountNonce"
 
 import {
     type SmartAccount,
@@ -24,12 +24,12 @@ import {
     toSmartAccount
 } from "viem/account-abstraction"
 import { getAction, toHex } from "viem/utils"
-import { type EthereumProvider, toOwner } from "../../utils/toOwner.js"
-import { encodeCallData } from "./utils/encodeCallData.js"
-import { getAccountAddress } from "./utils/getAccountAddress.js"
-import { getFactoryData } from "./utils/getFactoryData.js"
-import { signMessage } from "./utils/signMessage.js"
-import { signTypedData } from "./utils/signTypedData.js"
+import { type EthereumProvider, toOwner } from "../../utils/toOwner"
+import { encodeCallData } from "./utils/encodeCallData"
+import { getAccountAddress } from "./utils/getAccountAddress"
+import { getFactoryData } from "./utils/getFactoryData"
+import { signMessage } from "./utils/signMessage"
+import { signTypedData } from "./utils/signTypedData"
 
 /**
  * Default addresses for Thirdweb Smart Account

--- a/packages/permissionless/accounts/trust/toTrustSmartAccount.ts
+++ b/packages/permissionless/accounts/trust/toTrustSmartAccount.ts
@@ -13,7 +13,7 @@ import {
     hashTypedData
 } from "viem"
 import { getChainId, signMessage } from "viem/actions"
-import { getAccountNonce } from "../../actions/public/getAccountNonce.js"
+import { getAccountNonce } from "../../actions/public/getAccountNonce"
 
 import {
     type SmartAccount,
@@ -25,10 +25,10 @@ import {
     toSmartAccount
 } from "viem/account-abstraction"
 import { getAction } from "viem/utils"
-import { getSenderAddress } from "../../actions/public/getSenderAddress.js"
-import { type EthereumProvider, toOwner } from "../../utils/toOwner.js"
-import { encodeCallData } from "./utils/encodeCallData.js"
-import { getFactoryData } from "./utils/getFactoryData.js"
+import { getSenderAddress } from "../../actions/public/getSenderAddress"
+import { type EthereumProvider, toOwner } from "../../utils/toOwner"
+import { encodeCallData } from "./utils/encodeCallData"
+import { getFactoryData } from "./utils/getFactoryData"
 
 async function _signTypedData(
     signer: LocalAccount,

--- a/packages/permissionless/actions/erc7579.ts
+++ b/packages/permissionless/actions/erc7579.ts
@@ -3,40 +3,40 @@ import type {
     GetSmartAccountParameter,
     SmartAccount
 } from "viem/account-abstraction"
-import { accountId } from "./erc7579/accountId.js"
+import { accountId } from "./erc7579/accountId"
 import {
     type InstallModuleParameters,
     installModule
-} from "./erc7579/installModule.js"
+} from "./erc7579/installModule"
 import {
     type InstallModulesParameters,
     installModules
-} from "./erc7579/installModules.js"
+} from "./erc7579/installModules"
 import {
     type IsModuleInstalledParameters,
     isModuleInstalled
-} from "./erc7579/isModuleInstalled.js"
+} from "./erc7579/isModuleInstalled"
 import {
     type SupportsExecutionModeParameters,
     supportsExecutionMode
-} from "./erc7579/supportsExecutionMode.js"
+} from "./erc7579/supportsExecutionMode"
 import type {
     CallType,
     ExecutionMode
-} from "./erc7579/supportsExecutionMode.js"
+} from "./erc7579/supportsExecutionMode"
 import {
     type SupportsModuleParameters,
     supportsModule
-} from "./erc7579/supportsModule.js"
-import type { ModuleType } from "./erc7579/supportsModule.js"
+} from "./erc7579/supportsModule"
+import type { ModuleType } from "./erc7579/supportsModule"
 import {
     type UninstallModuleParameters,
     uninstallModule
-} from "./erc7579/uninstallModule.js"
+} from "./erc7579/uninstallModule"
 import {
     type UninstallModulesParameters,
     uninstallModules
-} from "./erc7579/uninstallModules.js"
+} from "./erc7579/uninstallModules"
 
 export type Erc7579Actions<TSmartAccount extends SmartAccount | undefined> = {
     accountId: (

--- a/packages/permissionless/actions/erc7579/accountId.ts
+++ b/packages/permissionless/actions/erc7579/accountId.ts
@@ -12,7 +12,7 @@ import type {
 } from "viem/account-abstraction"
 import { call, readContract } from "viem/actions"
 import { getAction } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
+import { AccountNotFoundError } from "../../errors/index"
 
 export async function accountId<TSmartAccount extends SmartAccount | undefined>(
     client: Client<Transport, Chain | undefined, TSmartAccount>,

--- a/packages/permissionless/actions/erc7579/installModule.ts
+++ b/packages/permissionless/actions/erc7579/installModule.ts
@@ -7,9 +7,9 @@ import {
     sendUserOperation
 } from "viem/account-abstraction"
 import { getAction, parseAccount } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
-import { encodeInstallModule } from "../../utils/encodeInstallModule.js"
-import type { ModuleType } from "./supportsModule.js"
+import { AccountNotFoundError } from "../../errors/index"
+import { encodeInstallModule } from "../../utils/encodeInstallModule"
+import type { ModuleType } from "./supportsModule"
 
 export type InstallModuleParameters<
     TSmartAccount extends SmartAccount | undefined,

--- a/packages/permissionless/actions/erc7579/installModules.ts
+++ b/packages/permissionless/actions/erc7579/installModules.ts
@@ -6,11 +6,11 @@ import {
     sendUserOperation
 } from "viem/account-abstraction"
 import { getAction, parseAccount } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
+import { AccountNotFoundError } from "../../errors/index"
 import {
     type EncodeInstallModuleParameters,
     encodeInstallModule
-} from "../../utils/encodeInstallModule.js"
+} from "../../utils/encodeInstallModule"
 
 export type InstallModulesParameters<
     TSmartAccount extends SmartAccount | undefined,

--- a/packages/permissionless/actions/erc7579/isModuleInstalled.ts
+++ b/packages/permissionless/actions/erc7579/isModuleInstalled.ts
@@ -16,8 +16,8 @@ import type {
 } from "viem/account-abstraction"
 import { call, readContract } from "viem/actions"
 import { getAction, parseAccount } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
-import { type ModuleType, parseModuleTypeId } from "./supportsModule.js"
+import { AccountNotFoundError } from "../../errors/index"
+import { type ModuleType, parseModuleTypeId } from "./supportsModule"
 
 export type IsModuleInstalledParameters<
     TSmartAccount extends SmartAccount | undefined

--- a/packages/permissionless/actions/erc7579/supportsExecutionMode.ts
+++ b/packages/permissionless/actions/erc7579/supportsExecutionMode.ts
@@ -17,7 +17,7 @@ import type {
 import { call, readContract } from "viem/actions"
 import { getAction } from "viem/utils"
 import { parseAccount } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
+import { AccountNotFoundError } from "../../errors/index"
 
 export type CallType = "call" | "delegatecall" | "batchcall"
 

--- a/packages/permissionless/actions/erc7579/supportsModule.ts
+++ b/packages/permissionless/actions/erc7579/supportsModule.ts
@@ -13,7 +13,7 @@ import type {
 import { call, readContract } from "viem/actions"
 import { getAction } from "viem/utils"
 import { parseAccount } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
+import { AccountNotFoundError } from "../../errors/index"
 
 export type ModuleType = "validator" | "executor" | "fallback" | "hook"
 

--- a/packages/permissionless/actions/erc7579/uninstallModule.ts
+++ b/packages/permissionless/actions/erc7579/uninstallModule.ts
@@ -16,9 +16,9 @@ import {
 } from "viem/account-abstraction"
 import { getAction } from "viem/utils"
 import { parseAccount } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
-import { encodeUninstallModule } from "../../utils/encodeUninstallModule.js"
-import type { ModuleType } from "./supportsModule.js"
+import { AccountNotFoundError } from "../../errors/index"
+import { encodeUninstallModule } from "../../utils/encodeUninstallModule"
+import type { ModuleType } from "./supportsModule"
 
 export type UninstallModuleParameters<
     TSmartAccount extends SmartAccount | undefined,

--- a/packages/permissionless/actions/erc7579/uninstallModules.ts
+++ b/packages/permissionless/actions/erc7579/uninstallModules.ts
@@ -7,11 +7,11 @@ import {
 } from "viem/account-abstraction"
 import { getAction } from "viem/utils"
 import { parseAccount } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
+import { AccountNotFoundError } from "../../errors/index"
 import {
     type EncodeUninstallModuleParameters,
     encodeUninstallModule
-} from "../../utils/encodeUninstallModule.js"
+} from "../../utils/encodeUninstallModule"
 
 export type UninstallModulesParameters<
     TSmartAccount extends SmartAccount | undefined,

--- a/packages/permissionless/actions/etherspot.ts
+++ b/packages/permissionless/actions/etherspot.ts
@@ -1,6 +1,6 @@
 import {
     type GetGasPriceResponseReturnType,
     getUserOperationGasPrice
-} from "./etherspot/getUserOperationGasPrice.js"
+} from "./etherspot/getUserOperationGasPrice"
 
 export { type GetGasPriceResponseReturnType, getUserOperationGasPrice }

--- a/packages/permissionless/actions/etherspot/getUserOperationGasPrice.ts
+++ b/packages/permissionless/actions/etherspot/getUserOperationGasPrice.ts
@@ -1,5 +1,5 @@
 import type { Account, Chain, Client, Transport } from "viem"
-import type { EtherspotBundlerRpcSchema } from "../../types/etherspot.js"
+import type { EtherspotBundlerRpcSchema } from "../../types/etherspot"
 
 export type GetGasPriceResponseReturnType = {
     maxFeePerGas: bigint

--- a/packages/permissionless/actions/index.ts
+++ b/packages/permissionless/actions/index.ts
@@ -1,11 +1,11 @@
-import type { GetSenderAddressParams } from "./public/getSenderAddress.js"
+import type { GetSenderAddressParams } from "./public/getSenderAddress"
 import {
     InvalidEntryPointError,
     getSenderAddress
-} from "./public/getSenderAddress.js"
+} from "./public/getSenderAddress"
 
-import type { GetAccountNonceParams } from "./public/getAccountNonce.js"
-import { getAccountNonce } from "./public/getAccountNonce.js"
+import type { GetAccountNonceParams } from "./public/getAccountNonce"
+import { getAccountNonce } from "./public/getAccountNonce"
 
 export type { GetSenderAddressParams, GetAccountNonceParams }
 

--- a/packages/permissionless/actions/pimlico.ts
+++ b/packages/permissionless/actions/pimlico.ts
@@ -2,34 +2,34 @@ import {
     type GetTokenQuotesParameters,
     type GetTokenQuotesReturnType,
     getTokenQuotes
-} from "./pimlico/getTokenQuotes.js"
+} from "./pimlico/getTokenQuotes"
 import {
     type GetUserOperationGasPriceReturnType,
     getUserOperationGasPrice
-} from "./pimlico/getUserOperationGasPrice.js"
+} from "./pimlico/getUserOperationGasPrice"
 import {
     type GetUserOperationStatusParameters,
     type GetUserOperationStatusReturnType,
     getUserOperationStatus
-} from "./pimlico/getUserOperationStatus.js"
+} from "./pimlico/getUserOperationStatus"
 import {
     type SendCompressedUserOperationParameters,
     sendCompressedUserOperation
-} from "./pimlico/sendCompressedUserOperation.js"
+} from "./pimlico/sendCompressedUserOperation"
 import {
     type PimlicoSponsorUserOperationParameters,
     type SponsorUserOperationReturnType,
     sponsorUserOperation
-} from "./pimlico/sponsorUserOperation.js"
+} from "./pimlico/sponsorUserOperation"
 
-import type { PimlicoActions } from "../clients/decorators/pimlico.js"
-import { pimlicoActions } from "../clients/decorators/pimlico.js"
+import type { PimlicoActions } from "../clients/decorators/pimlico"
+import { pimlicoActions } from "../clients/decorators/pimlico"
 
 import {
     type ValidateSponsorshipPolicies,
     type ValidateSponsorshipPoliciesParameters,
     validateSponsorshipPolicies
-} from "./pimlico/validateSponsorshipPolicies.js"
+} from "./pimlico/validateSponsorshipPolicies"
 
 export type {
     GetUserOperationGasPriceReturnType,

--- a/packages/permissionless/actions/pimlico/getTokenQuotes.ts
+++ b/packages/permissionless/actions/pimlico/getTokenQuotes.ts
@@ -9,7 +9,7 @@ import {
     hexToBigInt,
     numberToHex
 } from "viem"
-import type { PimlicoRpcSchema } from "../../types/pimlico.js"
+import type { PimlicoRpcSchema } from "../../types/pimlico"
 
 export type GetTokenQuotesParameters<
     TChain extends Chain | undefined,

--- a/packages/permissionless/actions/pimlico/getUserOperationGasPrice.ts
+++ b/packages/permissionless/actions/pimlico/getUserOperationGasPrice.ts
@@ -1,5 +1,5 @@
 import type { Account, Chain, Client, Transport } from "viem"
-import type { PimlicoRpcSchema } from "../../types/pimlico.js"
+import type { PimlicoRpcSchema } from "../../types/pimlico"
 
 export type GetUserOperationGasPriceReturnType = {
     slow: {

--- a/packages/permissionless/actions/pimlico/getUserOperationStatus.ts
+++ b/packages/permissionless/actions/pimlico/getUserOperationStatus.ts
@@ -2,7 +2,7 @@ import type { Account, Chain, Client, Hash, Transport } from "viem"
 import type {
     PimlicoRpcSchema,
     PimlicoUserOperationStatus
-} from "../../types/pimlico.js"
+} from "../../types/pimlico"
 
 export type GetUserOperationStatusParameters = {
     hash: Hash

--- a/packages/permissionless/actions/pimlico/sendCompressedUserOperation.ts
+++ b/packages/permissionless/actions/pimlico/sendCompressedUserOperation.ts
@@ -7,7 +7,7 @@ import type {
     Hex,
     Transport
 } from "viem"
-import type { PimlicoRpcSchema } from "../../types/pimlico.js"
+import type { PimlicoRpcSchema } from "../../types/pimlico"
 
 export type SendCompressedUserOperationParameters = {
     compressedUserOperation: Hex

--- a/packages/permissionless/actions/pimlico/sponsorUserOperation.ts
+++ b/packages/permissionless/actions/pimlico/sponsorUserOperation.ts
@@ -9,8 +9,8 @@ import type {
     Transport
 } from "viem"
 import type { UserOperation } from "viem/account-abstraction"
-import type { PimlicoRpcSchema } from "../../types/pimlico.js"
-import { deepHexlify } from "../../utils/deepHexlify.js"
+import type { PimlicoRpcSchema } from "../../types/pimlico"
+import { deepHexlify } from "../../utils/deepHexlify"
 
 export type PimlicoSponsorUserOperationParameters<
     entryPointVersion extends "0.6" | "0.7"

--- a/packages/permissionless/actions/pimlico/validateSponsorshipPolicies.ts
+++ b/packages/permissionless/actions/pimlico/validateSponsorshipPolicies.ts
@@ -1,7 +1,7 @@
 import type { Account, Address, Chain, Client, Transport } from "viem"
 import type { UserOperation } from "viem/account-abstraction"
-import type { PimlicoRpcSchema } from "../../types/pimlico.js"
-import { deepHexlify } from "../../utils/deepHexlify.js"
+import type { PimlicoRpcSchema } from "../../types/pimlico"
+import { deepHexlify } from "../../utils/deepHexlify"
 
 export type ValidateSponsorshipPoliciesParameters = {
     userOperation: UserOperation

--- a/packages/permissionless/actions/smartAccount.ts
+++ b/packages/permissionless/actions/smartAccount.ts
@@ -1,9 +1,9 @@
-import { sendTransaction } from "./smartAccount/sendTransaction.js"
+import { sendTransaction } from "./smartAccount/sendTransaction"
 
-import { signMessage } from "./smartAccount/signMessage.js"
+import { signMessage } from "./smartAccount/signMessage"
 
-import { signTypedData } from "./smartAccount/signTypedData.js"
+import { signTypedData } from "./smartAccount/signTypedData"
 
-import { writeContract } from "./smartAccount/writeContract.js"
+import { writeContract } from "./smartAccount/writeContract"
 
 export { sendTransaction, signMessage, signTypedData, writeContract }

--- a/packages/permissionless/actions/smartAccount/sendTransaction.ts
+++ b/packages/permissionless/actions/smartAccount/sendTransaction.ts
@@ -12,7 +12,7 @@ import {
     waitForUserOperationReceipt
 } from "viem/account-abstraction"
 import { getAction, parseAccount } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
+import { AccountNotFoundError } from "../../errors/index"
 
 /**
  * Creates, signs, and sends a new transaction to the network.

--- a/packages/permissionless/actions/smartAccount/signMessage.ts
+++ b/packages/permissionless/actions/smartAccount/signMessage.ts
@@ -7,7 +7,7 @@ import type {
 } from "viem"
 import type { SmartAccount } from "viem/account-abstraction"
 import { parseAccount } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
+import { AccountNotFoundError } from "../../errors/index"
 
 /**
  * Calculates an Ethereum-specific signature in [EIP-191 format](https://eips.ethereum.org/EIPS/eip-191): `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`.

--- a/packages/permissionless/actions/smartAccount/signTypedData.ts
+++ b/packages/permissionless/actions/smartAccount/signTypedData.ts
@@ -12,7 +12,7 @@ import {
 } from "viem"
 import type { SmartAccount } from "viem/account-abstraction"
 import { parseAccount } from "viem/utils"
-import { AccountNotFoundError } from "../../errors/index.js"
+import { AccountNotFoundError } from "../../errors/index"
 
 /**
  * Signs typed data and calculates an Ethereum-specific signature in [https://eips.ethereum.org/EIPS/eip-712](https://eips.ethereum.org/EIPS/eip-712): `sign(keccak256("\x19\x01" ‖ domainSeparator ‖ hashStruct(message)))`

--- a/packages/permissionless/actions/smartAccount/writeContract.ts
+++ b/packages/permissionless/actions/smartAccount/writeContract.ts
@@ -13,7 +13,7 @@ import {
 } from "viem"
 import type { SmartAccount } from "viem/account-abstraction"
 import { getAction } from "viem/utils"
-import { sendTransaction } from "./sendTransaction.js"
+import { sendTransaction } from "./sendTransaction"
 
 export async function writeContract<
     TChain extends Chain | undefined,

--- a/packages/permissionless/clients/createSmartAccountClient.ts
+++ b/packages/permissionless/clients/createSmartAccountClient.ts
@@ -22,7 +22,7 @@ import {
 import {
     type SmartAccountActions,
     smartAccountActions
-} from "./decorators/smartAccount.js"
+} from "./decorators/smartAccount"
 
 /**
  * TODO:

--- a/packages/permissionless/clients/decorators/pimlico.ts
+++ b/packages/permissionless/clients/decorators/pimlico.ts
@@ -8,21 +8,21 @@ import {
     getTokenQuotes,
     sendCompressedUserOperation,
     validateSponsorshipPolicies
-} from "../../actions/pimlico.js"
+} from "../../actions/pimlico"
 import {
     type GetUserOperationGasPriceReturnType,
     getUserOperationGasPrice
-} from "../../actions/pimlico/getUserOperationGasPrice.js"
+} from "../../actions/pimlico/getUserOperationGasPrice"
 import {
     type GetUserOperationStatusParameters,
     type GetUserOperationStatusReturnType,
     getUserOperationStatus
-} from "../../actions/pimlico/getUserOperationStatus.js"
+} from "../../actions/pimlico/getUserOperationStatus"
 import {
     type PimlicoSponsorUserOperationParameters,
     type SponsorUserOperationReturnType,
     sponsorUserOperation
-} from "../../actions/pimlico/sponsorUserOperation.js"
+} from "../../actions/pimlico/sponsorUserOperation"
 
 export type PimlicoActions<
     TChain extends Chain | undefined,

--- a/packages/permissionless/clients/decorators/smartAccount.ts
+++ b/packages/permissionless/clients/decorators/smartAccount.ts
@@ -11,10 +11,10 @@ import type {
     WriteContractParameters
 } from "viem"
 import type { SmartAccount } from "viem/account-abstraction"
-import { sendTransaction } from "../../actions/smartAccount/sendTransaction.js"
-import { signMessage } from "../../actions/smartAccount/signMessage.js"
-import { signTypedData } from "../../actions/smartAccount/signTypedData.js"
-import { writeContract } from "../../actions/smartAccount/writeContract.js"
+import { sendTransaction } from "../../actions/smartAccount/sendTransaction"
+import { signMessage } from "../../actions/smartAccount/signMessage"
+import { signTypedData } from "../../actions/smartAccount/signTypedData"
+import { writeContract } from "../../actions/smartAccount/writeContract"
 
 export type SmartAccountActions<
     TChain extends Chain | undefined = Chain | undefined,

--- a/packages/permissionless/clients/index.ts
+++ b/packages/permissionless/clients/index.ts
@@ -1,2 +1,2 @@
-export * from "./createSmartAccountClient.js"
-export * from "./decorators/smartAccount.js"
+export * from "./createSmartAccountClient"
+export * from "./decorators/smartAccount"

--- a/packages/permissionless/clients/pimlico.ts
+++ b/packages/permissionless/clients/pimlico.ts
@@ -17,8 +17,8 @@ import {
     entryPoint07Address,
     paymasterActions
 } from "viem/account-abstraction"
-import type { PimlicoRpcSchema } from "../types/pimlico.js"
-import { type PimlicoActions, pimlicoActions } from "./decorators/pimlico.js"
+import type { PimlicoRpcSchema } from "../types/pimlico"
+import { type PimlicoActions, pimlicoActions } from "./decorators/pimlico"
 
 export type PimlicoClient<
     entryPointVersion extends "0.6" | "0.7" = "0.7" | "0.6",

--- a/packages/permissionless/experimental/pimlico/index.ts
+++ b/packages/permissionless/experimental/pimlico/index.ts
@@ -1,2 +1,2 @@
-import { prepareUserOperationForErc20Paymaster } from "./utils/prepareUserOperationForErc20Paymaster.js"
+import { prepareUserOperationForErc20Paymaster } from "./utils/prepareUserOperationForErc20Paymaster"
 export { prepareUserOperationForErc20Paymaster }

--- a/packages/permissionless/experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.ts
+++ b/packages/permissionless/experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.ts
@@ -26,9 +26,9 @@ import {
 import { getChainId as getChainId_ } from "viem/actions"
 import { readContract } from "viem/actions"
 import { getAction, parseAccount } from "viem/utils"
-import { getTokenQuotes } from "../../../actions/pimlico.js"
-import { erc20AllowanceOverride } from "../../../utils/erc20AllowanceOverride.js"
-import { erc20BalanceOverride } from "../../../utils/erc20BalanceOverride.js"
+import { getTokenQuotes } from "../../../actions/pimlico"
+import { erc20AllowanceOverride } from "../../../utils/erc20AllowanceOverride"
+import { erc20BalanceOverride } from "../../../utils/erc20BalanceOverride"
 
 export const prepareUserOperationForErc20Paymaster =
     (

--- a/packages/permissionless/index.ts
+++ b/packages/permissionless/index.ts
@@ -1,3 +1,3 @@
-export * from "./utils/index.js"
-export * from "./errors/index.js"
-export * from "./clients/index.js"
+export * from "./utils/index"
+export * from "./errors/index"
+export * from "./clients/index"

--- a/packages/permissionless/utils/encode7579Calls.ts
+++ b/packages/permissionless/utils/encode7579Calls.ts
@@ -10,7 +10,7 @@ import {
     type CallType,
     type ExecutionMode,
     encodeExecutionMode
-} from "../actions/erc7579/supportsExecutionMode.js"
+} from "../actions/erc7579/supportsExecutionMode"
 
 export type EncodeCallDataParams<callType extends CallType> = {
     mode: ExecutionMode<callType>

--- a/packages/permissionless/utils/encodeInstallModule.ts
+++ b/packages/permissionless/utils/encodeInstallModule.ts
@@ -12,8 +12,8 @@ import type {
 import {
     type ModuleType,
     parseModuleTypeId
-} from "../actions/erc7579/supportsModule.js"
-import { AccountNotFoundError } from "../errors/index.js"
+} from "../actions/erc7579/supportsModule"
+import { AccountNotFoundError } from "../errors/index"
 
 export type EncodeInstallModuleParameter = {
     type: ModuleType

--- a/packages/permissionless/utils/encodeUninstallModule.ts
+++ b/packages/permissionless/utils/encodeUninstallModule.ts
@@ -12,8 +12,8 @@ import type {
 import {
     type ModuleType,
     parseModuleTypeId
-} from "../actions/erc7579/supportsModule.js"
-import { AccountNotFoundError } from "../errors/index.js"
+} from "../actions/erc7579/supportsModule"
+import { AccountNotFoundError } from "../errors/index"
 
 export type EncodeUninstallModuleParameter = {
     type: ModuleType

--- a/packages/permissionless/utils/index.ts
+++ b/packages/permissionless/utils/index.ts
@@ -1,33 +1,33 @@
-import { deepHexlify, transactionReceiptStatus } from "./deepHexlify.js"
-import { getAddressFromInitCodeOrPaymasterAndData } from "./getAddressFromInitCodeOrPaymasterAndData.js"
+import { deepHexlify, transactionReceiptStatus } from "./deepHexlify"
+import { getAddressFromInitCodeOrPaymasterAndData } from "./getAddressFromInitCodeOrPaymasterAndData"
 import {
     type GetRequiredPrefundReturnType,
     getRequiredPrefund
-} from "./getRequiredPrefund.js"
-import { isSmartAccountDeployed } from "./isSmartAccountDeployed.js"
-import { toOwner } from "./toOwner.js"
+} from "./getRequiredPrefund"
+import { isSmartAccountDeployed } from "./isSmartAccountDeployed"
+import { toOwner } from "./toOwner"
 
-import { decodeNonce } from "./decodeNonce.js"
-import { encodeNonce } from "./encodeNonce.js"
+import { decodeNonce } from "./decodeNonce"
+import { encodeNonce } from "./encodeNonce"
 
 import {
     type EncodeInstallModuleParameters,
     encodeInstallModule
-} from "./encodeInstallModule.js"
-import { getPackedUserOperation } from "./getPackedUserOperation.js"
+} from "./encodeInstallModule"
+import { getPackedUserOperation } from "./getPackedUserOperation"
 
 import {
     type EncodeCallDataParams,
     encode7579Calls
-} from "./encode7579Calls.js"
+} from "./encode7579Calls"
 import {
     type Erc20AllowanceOverrideParameters,
     erc20AllowanceOverride
-} from "./erc20AllowanceOverride.js"
+} from "./erc20AllowanceOverride"
 import {
     type Erc20BalanceOverrideParameters,
     erc20BalanceOverride
-} from "./erc20BalanceOverride.js"
+} from "./erc20BalanceOverride"
 
 export {
     transactionReceiptStatus,

--- a/packages/wagmi/hooks/useAvailableCapabilities.ts
+++ b/packages/wagmi/hooks/useAvailableCapabilities.ts
@@ -4,7 +4,7 @@ import { useContext, useMemo } from "react"
 import type { WalletCapabilities, WalletSendCallsParameters } from "viem"
 import { useAccount } from "wagmi"
 import { useCapabilities } from "wagmi/experimental"
-import { PermissionlessContext } from "../context.js"
+import { PermissionlessContext } from "../context"
 
 export const useAvailableCapabilities = () => {
     const { capabilities: capabilitiesConfigured } = useContext(

--- a/packages/wagmi/hooks/useSendTransaction.ts
+++ b/packages/wagmi/hooks/useSendTransaction.ts
@@ -18,7 +18,7 @@ import type {
     UseMutationParameters,
     UseMutationReturnType
 } from "wagmi/query"
-import { useAvailableCapabilities } from "./useAvailableCapabilities.js"
+import { useAvailableCapabilities } from "./useAvailableCapabilities"
 
 const sendTransactionMutationOptions = <config extends Config>(
     config: config,

--- a/packages/wagmi/hooks/useWaitForTransactionReceipt.ts
+++ b/packages/wagmi/hooks/useWaitForTransactionReceipt.ts
@@ -45,9 +45,9 @@ import {
     type WaitForTransactionReceiptQueryFnData,
     useQuery
 } from "wagmi/query"
-import { observe } from "../utils/observe.js"
-import { useAvailableCapabilities } from "./useAvailableCapabilities.js"
-import type { ConfigParameter } from "./useSendTransaction.js"
+import { observe } from "../utils/observe"
+import { useAvailableCapabilities } from "./useAvailableCapabilities"
+import type { ConfigParameter } from "./useSendTransaction"
 
 export type WaitForTransactionReceiptQueryKey<
     config extends Config,

--- a/packages/wagmi/index.ts
+++ b/packages/wagmi/index.ts
@@ -1,15 +1,15 @@
 export {
     PermissionlessProvider,
     type PermissionlessProviderProps
-} from "./context.js"
+} from "./context"
 
 export {
     useSendTransaction,
     type UseSendTransactionParameters,
     type UseSendTransactionReturnType
-} from "./hooks/useSendTransaction.js"
+} from "./hooks/useSendTransaction"
 export {
     useWaitForTransactionReceipt,
     type UseWaitForTransactionReceiptParameters,
     type UseWaitForTransactionReceiptReturnType
-} from "./hooks/useWaitForTransactionReceipt.js"
+} from "./hooks/useWaitForTransactionReceipt"


### PR DESCRIPTION
This may resolve https://github.com/pimlicolabs/permissionless.js/issues/61

Some environments using .ts files may fail when the imports inside the lib are pointing to .js files specifically. Anecdotally this solves the problem on my RN expo project but should probably be tested in other environments.

Tested on:
Expo 51 
React Native 74

PR generated by doing a regex find and replace with the following in case it needs to be adjusted further
find: from\s+(['"](\.{1,2}\/)+[^'"]+)\.js(['"])
replace: from $1$3