### PR TITLE
use localOwners in signUserOperation on toSafeSmartAccount

### DIFF
--- a/.changeset/four-eggs-deny.md
+++ b/.changeset/four-eggs-deny.md
@@ -2,4 +2,4 @@
 "permissionless": patch
 ---
 
-fix safe userOp signing
+Fixed `signUserOperation` for `toSafeSmartAccount` when owner is not a LocalAccount.

--- a/.changeset/four-eggs-deny.md
+++ b/.changeset/four-eggs-deny.md
@@ -1,0 +1,5 @@
+---
+"permissionless": patch
+---
+
+fix safe userOp signing

--- a/packages/permissionless-test/src/testWithRpc.ts
+++ b/packages/permissionless-test/src/testWithRpc.ts
@@ -30,11 +30,16 @@ export const getInstances = async ({
         | string
         | undefined
 
-    const anvilInstance = anvil({
-        chainId: foundry.id,
-        port: anvilPort,
-        forkUrl
-    })
+    const anvilInstance = forkUrl
+        ? anvil({
+              chainId: foundry.id,
+              port: anvilPort,
+              forkUrl
+          })
+        : anvil({
+              chainId: foundry.id,
+              port: anvilPort
+          })
 
     const altoInstance = alto({
         entrypoints: [entryPoint06Address, entryPoint07Address],

--- a/packages/permissionless/accounts/safe/toSafeSmartAccount.ts
+++ b/packages/permissionless/accounts/safe/toSafeSmartAccount.ts
@@ -1525,7 +1525,7 @@ export async function toSafeSmartAccount<
 
             let signatures: Hex | undefined = undefined
 
-            for (const owner of owners) {
+            for (const owner of localOwners) {
                 signatures = await signUserOperation({
                     ...userOperation,
                     version,


### PR DESCRIPTION
Fix to enable signing with json-rpc wallet connections (e.g. metamask)