### PR TITLE
Update setup-bun Action to v2

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Bun
-      uses: oven-sh/setup-bun@v1
+      uses: oven-sh/setup-bun@v2
       with:
         bun-version: 1.0.30
 


### PR DESCRIPTION
This pull request updates oven-sh/setup-bun from v1 to v2 in .github/actions/install-dependencies/action.yml.
The v2 release provides better version control, improved caching, and enhanced stability.
Updating ensures compatibility with the latest Bun CI/CD practices and recommended installation methods.

Official Documentation:

https://bun.sh/guides/runtime/cicd