### PR TITLE
bump ox to match viem

### DIFF
--- a/packages/permissionless/package.json
+++ b/packages/permissionless/package.json
@@ -92,7 +92,7 @@
     },
     "peerDependencies": {
         "viem": "^2.23.2",
-        "ox": "0.6.7"
+        "ox": "0.6.9"
     },
     "peerDependenciesMeta": {
         "ox": {

--- a/packages/permissionless/package.json
+++ b/packages/permissionless/package.json
@@ -91,7 +91,7 @@
         }
     },
     "peerDependencies": {
-        "viem": "^2.23.2",
+        "viem": "^2.24.0",
         "ox": "0.6.9"
     },
     "peerDependenciesMeta": {


### PR DESCRIPTION
viem^2.24.0 uses a pinned version of ox at 0.6.9.
Bumping both viem and ox versions to make it work with latest viem version.