### PR TITLE
fix: return the full userOperationReceipt

### DIFF
--- a/packages/permissionless/actions/smartAccount/sendTransaction.ts
+++ b/packages/permissionless/actions/smartAccount/sendTransaction.ts
@@ -129,5 +129,5 @@ export async function sendTransaction<
         hash: userOpHash
     })
 
-    return userOperationReceipt?.receipt.transactionHash
+    return userOperationReceipt
 }


### PR DESCRIPTION
In [erc-7769](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-7769.md#eth_getuseroperationreceipt), it defines the return value of `eth_getUserOperationReceipt`, and it includes the the `TransactionReceipt` object which is for the entire bundle, not only for this `UserOperation`. This allows developers to retrieve the transaction status and potential error reasons from the receipt.

I suggest returning the full `userOperationReceipt` instead of just the transaction hash to provide more comprehensive data about this transaction. 

Additionally, [viem](https://github.com/wevm/viem/blob/main/src/account-abstraction/actions/bundler/waitForUserOperationReceipt.ts#L69)'s implementation already follows this specification.