### PR TITLE
Prevent redundant eip7702Auth inclusion in UserOps to avoid unnecessary type 4 tx overhead

### DIFF
--- a/.changeset/kip-redundant-7702-auth.md
+++ b/.changeset/kip-redundant-7702-auth.md
@@ -1,0 +1,6 @@
+---
+"permissionless": patch
+---
+
+Skip adding `authorization` to `sendTransaction` when the account is already 7702-attached to the same address. 
+This prevents redundant Type-4 overhead in UserOps and reduces calldata/gas; no changes required for consumers.


### PR DESCRIPTION
# Summary

This PR fixes an issue where the permissionless lib always forwards the authorization field (eip7702Auth) to the bundler, even if the account has already been authorized with the same delegation.

Currently, this causes all subsequent UserOps to be bundled into type 4 transactions, which adds ~23,000 gas overhead per transaction. This is not required by EIP-7702 semantics and results in wasted gas for users.

# Changes
In `actions/smartAccount/sendTransaction.ts`, before forwarding arguments to `sendUserOperation`, we:

Retrieve deployed bytecode for the account.

Detect if the account is already attached via 7702 (prefix 0xef0100).

Extract the attached delegate address.

If it matches the authorization.address provided, remove the redundant authorization field.

```ts
if ("authorization" in args && args.authorization) {
  const bytecode = await getCode(client, { address: account.address })

  if (bytecode) {
    const bc = bytecode.toLowerCase()
    // "0x" + "ef0100" + 20-byte address (40 hex chars)
    if (bc.startsWith("0xef0100") && bc.length >= 48) {
      const attachedAddress = "0x" + bc.slice(8, 48)
      const target = (args.authorization as any).address?.toLowerCase?.()
      if (target && attachedAddress === target) {
        delete (args as any).authorization
      }
    }
  }
}
```

# Rationale
- **User benefit**: prevents every tx from incurring the extra type 4 overhead once the account is already authorized.

- **Spec alignment**: EIP-7702 only requires including eip7702Auth when setting or changing delegation, not on every tx.

- **Safety**: redelegations are still supported — if the target differs, the field is preserved.

# Example
UserOp
https://etherscan.io/tx/0xa9ba257d5c5231cecbcb9f0da54597777cff44309267ea931b6c1b253b2a0901

Account
https://etherscan.io/address/0xa764D0B9777cc53A0620650d3A089091272A9Bea#authlist7702