### PR TITLE
chore: clean up docsPath type

### DIFF
--- a/packages/permissionless/errors/index.ts
+++ b/packages/permissionless/errors/index.ts
@@ -1,7 +1,7 @@
 import { BaseError } from "viem"
 
 export class AccountNotFoundError extends BaseError {
-    constructor({ docsPath }: { docsPath?: string | undefined } = {}) {
+    constructor({ docsPath }: { docsPath?: string } = {}) {
         super(
             [
                 "Could not find an Account to execute with this Action.",


### PR DESCRIPTION
removed '| undefined' since '?' already does the job.
type is simpler now.