### PR TITLE
feat(simple): add 7702 factory for entrypoint v0.8

### DIFF
--- a/.changeset/strong-tires-like.md
+++ b/.changeset/strong-tires-like.md
@@ -1,0 +1,5 @@
+---
+"permissionless": patch
+---
+
+Fixed to7702SimpleSmartAccount by adding 0x7702 marker in factoryData

--- a/packages/mock-paymaster/helpers/schema.ts
+++ b/packages/mock-paymaster/helpers/schema.ts
@@ -113,7 +113,11 @@ const userOperationSchemaPaymasterV7 = z
     .object({
         sender: addressSchema,
         nonce: hexNumberSchema,
-        factory: addressSchema.optional().transform((val) => val ?? undefined),
+        factory: z
+            .union([addressSchema, z.literal("0x7702")])
+            .nullable()
+            .optional()
+            .transform((val) => val ?? null),
         factoryData: hexDataSchema
             .optional()
             .transform((val) => val ?? undefined),
@@ -208,7 +212,8 @@ const eip7677UserOperationSchemaV7 = z
     .object({
         sender: addressSchema,
         nonce: hexNumberSchema,
-        factory: addressSchema
+        factory: z
+            .union([addressSchema, z.literal("0x7702")])
             .nullable()
             .optional()
             .transform((val) => val ?? null),

--- a/packages/permissionless/accounts/simple/toSimpleSmartAccount.ts
+++ b/packages/permissionless/accounts/simple/toSimpleSmartAccount.ts
@@ -240,6 +240,12 @@ export async function toSimpleSmartAccount<
             return {
                 accountAddress: localOwner.address,
                 getFactoryArgs: async () => {
+                    if (entryPoint.version === "0.8") {
+                        return {
+                            factory: "0x7702" as Hex,
+                            factoryData: undefined
+                        }
+                    }
                     return {
                         factory: undefined,
                         factoryData: undefined


### PR DESCRIPTION
- Return factory address 0x7702 when using EntryPoint v0.8

- Enables EIP-7702 native account abstraction support
