### PR TITLE
chore(ci): explicitly pass codecov token to reusable workflow

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -11,8 +11,6 @@ jobs:
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   docker-e2e:
     name: E2E-Coverage

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -12,8 +12,6 @@ jobs:
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   changesets:
     name: Changesets


### PR DESCRIPTION
- Replace 'secrets: inherit' with explicit CODECOV_TOKEN secret

- Apply to both on-pull-request and on-push-to-main workflows
