### PR TITLE
Add missing zod-validation-error dependency to mock-paymaster

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,11 +40,12 @@
     },
     "packages/mock-paymaster": {
       "name": "@pimlico/mock-paymaster",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@fastify/cors": "^8.5.0",
         "fastify": "^4.28.1",
         "zod": "^3.24.2",
+        "zod-validation-error": "^1.3.0",
       },
       "peerDependencies": {
         "prool": "^0.0.25",
@@ -53,7 +54,7 @@
     },
     "packages/permissionless": {
       "name": "permissionless",
-      "version": "0.2.57",
+      "version": "0.3.0",
       "peerDependencies": {
         "ox": "^0.8.0",
         "viem": "^2.28.1",

--- a/packages/mock-paymaster/package.json
+++ b/packages/mock-paymaster/package.json
@@ -27,6 +27,7 @@
     "dependencies": {
         "@fastify/cors": "^8.5.0",
         "fastify": "^4.28.1",
-        "zod": "^3.24.2"
+        "zod": "^3.24.2",
+        "zod-validation-error": "^1.3.0"
     }
 }


### PR DESCRIPTION
Add missing zod-validation-error dependency. I'm assuming version `^1.3.0` is the correct one.
There are a few other updates to `bun.lock` after running `bun install`