### PR TITLE
feat(safe): skip MultiSend wrapping for single setup transaction

### DIFF
--- a/.changeset/neat-planets-talk.md
+++ b/.changeset/neat-planets-talk.md
@@ -1,0 +1,5 @@
+---
+"permissionless": patch
+---
+
+Added useMultiSendForSetup to skip multi-send call during setup

--- a/packages/permissionless/package.json
+++ b/packages/permissionless/package.json
@@ -11,13 +11,7 @@
     "type": "module",
     "sideEffects": false,
     "description": "A utility library for working with ERC-4337",
-    "keywords": [
-        "ethereum",
-        "erc-4337",
-        "eip-4337",
-        "paymaster",
-        "bundler"
-    ],
+    "keywords": ["ethereum", "erc-4337", "eip-4337", "paymaster", "bundler"],
     "license": "MIT",
     "exports": {
         ".": {


### PR DESCRIPTION
When initializing a Safe account with only one setup transaction (just enableModules, no WebAuthn or setupTransactions), call SafeModuleSetup.enableModules directly instead of wrapping it in MultiSend.multiSend(). This matches the behavior of Safe Protocol Kit / relay-kit, which optimizes single-transaction setups by skipping MultiSend.

This ensures address compatibility: the same owner, salt nonce, and Safe version produce the same counterfactual address regardless of whether permissionless.js or Safe Protocol Kit is used for derivation.

When multiple setup transactions exist (WebAuthn, setupTransactions, or extra safeModules), the MultiSend path is still used as before.