### PR TITLE
fix: avoid bigint exponentiation for Turbopack compatibility

### DIFF
--- a/.changeset/turbopack-bigint-exponentiation.md
+++ b/.changeset/turbopack-bigint-exponentiation.md
@@ -1,0 +1,5 @@
+---
+"permissionless": patch
+---
+
+Replace bigint exponentiation with BigInt(1e18) in estimateErc20PaymasterCost for Turbopack compatibility

--- a/packages/permissionless/actions/pimlico/estimateErc20PaymasterCost.ts
+++ b/packages/permissionless/actions/pimlico/estimateErc20PaymasterCost.ts
@@ -90,10 +90,10 @@ export const estimateErc20PaymasterCost = async <
         userOperationMaxCost + postOpGas * userOperation.maxFeePerGas
 
     // represents the userOperation's max cost in token denomination (wei)
-    const costInToken = (maxCostInWei * exchangeRate) / BigInt(1e18)
+    const costInToken = (maxCostInWei * exchangeRate) / 1_000_000_000_000_000_000n
 
     // represents the userOperation's max cost in usd (with 6 decimals of precision)
-    const costInUsd = (maxCostInWei * exchangeRateNativeToUsd) / 10n ** 18n
+    const costInUsd = (maxCostInWei * exchangeRateNativeToUsd) / 1_000_000_000_000_000_000n
 
     return {
         costInToken,

--- a/packages/permissionless/actions/pimlico/estimateErc20PaymasterCost.ts
+++ b/packages/permissionless/actions/pimlico/estimateErc20PaymasterCost.ts
@@ -90,10 +90,10 @@ export const estimateErc20PaymasterCost = async <
         userOperationMaxCost + postOpGas * userOperation.maxFeePerGas
 
     // represents the userOperation's max cost in token denomination (wei)
-    const costInToken = (maxCostInWei * exchangeRate) / 1_000_000_000_000_000_000n
+    const costInToken = (maxCostInWei * exchangeRate) / BigInt(1e18)
 
     // represents the userOperation's max cost in usd (with 6 decimals of precision)
-    const costInUsd = (maxCostInWei * exchangeRateNativeToUsd) / 1_000_000_000_000_000_000n
+    const costInUsd = (maxCostInWei * exchangeRateNativeToUsd) / BigInt(1e18)
 
     return {
         costInToken,


### PR DESCRIPTION
Replaces `10n ** 18n` and `BigInt(1e18)` with `1_000_000_000_000_000_000n` in `estimateErc20PaymasterCost`.

Two problems in the original code:
- `10n ** 18n` crashes Turbopack — it doesn't support the `**` operator with bigint operands yet ("right-associative binary expression not yet implemented").
- `BigInt(1e18)` on the adjacent line converts a Number to BigInt; `1e18` is at the edge of `Number.MAX_SAFE_INTEGER` and the pattern is imprecise in general.

A bigint literal avoids both issues. Low risk: replaces a bigint exponent expression and a Number-to-BigInt cast with an equivalent bigint literal, avoiding the Turbopack parser limitation without changing the computed value.

Closes #499