### PR TITLE
docs(testing): document test infrastructure end-to-end

### DIFF
--- a/docs/testing/01-architecture.md
+++ b/docs/testing/01-architecture.md
@@ -1,0 +1,181 @@
+# 01 — Architecture
+
+This document explains the big picture of `bun run test`: what is actually invoked, how Vitest is configured, where tests live, and how the pieces plug together.
+
+## The command chain
+
+### What `bun run test` runs
+
+From `package.json:92`:
+
+```json
+"test": "vitest dev -c ./packages/permissionless/vitest.config.ts"
+```
+
+- `bun run test` is just a thin wrapper — `bun` reads `package.json` and executes the string above.
+- `vitest dev` starts Vitest in **watch mode** (re-runs on file change) using the specified config file.
+- The config file lives **inside the package** being tested (`packages/permissionless/vitest.config.ts`), not at the repo root. This matters because `vitest.config.ts:28` uses `join(__dirname, "./**/*.test.ts")` to build its glob — meaning test discovery is rooted at `packages/permissionless/`, not at the repo root or CWD.
+
+There are two CI variants (also in `package.json`):
+
+```json
+"test:ci-no-coverage": "CI=true && vitest -c ./packages/permissionless/vitest.config.ts --pool=forks",
+"test:ci":             "CI=true && vitest -c ./packages/permissionless/vitest.config.ts --coverage --pool=forks"
+```
+
+CI differences are covered in [06-ci-and-running.md](./06-ci-and-running.md).
+
+### End-to-end flow
+
+```
+bun run test
+   │
+   └─► vitest dev -c packages/permissionless/vitest.config.ts
+          │
+          ├─ loads vitest.config.ts
+          │     - glob:       packages/permissionless/**/*.test.ts
+          │     - env:        loadEnv("test", process.cwd())     (→ .env.test, .env)
+          │     - environment: node
+          │     - sequence.concurrent: false  (tests in file serial)
+          │     - fileParallelism:     true   (files run in parallel)
+          │     - testTimeout: 60s, hookTimeout: 45s
+          │
+          ├─ for each test file, in its own worker:
+          │     import { testWithRpc } from "…/testWithRpc"
+          │     import { getCoreSmartAccounts, ... } from "…/utils"
+          │     describe.each(getCoreSmartAccounts())(...)  ← matrix over accounts
+          │         testWithRpc("...", async ({ rpc }) => { ... })
+          │
+          └─ per test() invocation:
+                1. testWithRpc fixture allocates 3 ports
+                2. spawns anvil → setupContracts → alto → mock-paymaster
+                3. awaits the test body with { rpc: { anvilRpc, altoRpc, paymasterRpc } }
+                4. stops all 3 instances, releases ports
+```
+
+Fixture mechanics are detailed in [02-lifecycle.md](./02-lifecycle.md); process details in [03-infrastructure.md](./03-infrastructure.md).
+
+## `vitest.config.ts` deep dive
+
+The full file (`packages/permissionless/vitest.config.ts:1`):
+
+```ts
+import { join } from "node:path"
+import { loadEnv } from "vite"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+    test: {
+        coverage: {
+            all: true,
+            provider: "v8",
+            reporter: process.env.CI ? ["lcov"] : ["text", "json", "html"],
+            include: ["**/permissionless/**"],
+            exclude: [
+                "**/errors/utils.ts",
+                "**/*.test.ts",
+                "**/permissionless-test/**",
+                "**/_cjs/**",
+                "**/_esm/**",
+                "**/_types/**"
+            ]
+        },
+        sequence: { concurrent: false },
+        fileParallelism: true,
+        environment: "node",
+        testTimeout: 60_000,
+        hookTimeout: 45_000,
+        include: [join(__dirname, "./**/*.test.ts")],
+        env: loadEnv("test", process.cwd())
+    }
+})
+```
+
+Field-by-field:
+
+| Field                       | Value                                            | Why it matters                                                                                                         |
+| --------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `coverage.provider`         | `"v8"`                                           | V8's native coverage; no Istanbul instrumentation.                                                                     |
+| `coverage.reporter`         | `CI ? ["lcov"] : ["text","json","html"]`         | Local dev gets HTML + text output; CI produces only lcov (Codecov-friendly).                                           |
+| `coverage.include`          | `["**/permissionless/**"]`                       | Measures coverage of the published package only.                                                                       |
+| `coverage.exclude`          | test files, generated `_cjs`/`_esm`/`_types`, test infra | Keeps coverage numbers honest.                                                                                         |
+| `sequence.concurrent`       | `false`                                          | Tests inside one file run **sequentially**. Multiple parallel Anvil stacks from one file would risk port exhaustion and noisy logs. |
+| `fileParallelism`           | `true`                                           | Separate `.test.ts` files DO run in parallel (in separate workers).                                                    |
+| `environment`               | `"node"`                                         | No jsdom; tests run in raw Node.                                                                                       |
+| `testTimeout`               | `60_000` (60s)                                   | User operations + bundling + receipts are slow; 60s is the per-test cap.                                               |
+| `hookTimeout`               | `45_000` (45s)                                   | The `testWithRpc` fixture setup (anvil + contracts + alto + paymaster) can take tens of seconds cold.                  |
+| `include`                   | `join(__dirname, "./**/*.test.ts")`              | Discovery is rooted at `packages/permissionless/` — not the repo root. Tests elsewhere (e.g. `packages/mock-paymaster/`) are **not** picked up. |
+| `env`                       | `loadEnv("test", process.cwd())`                 | Reads `.env.test`, `.env.test.local`, `.env`, `.env.local` from the CWD and exposes `VITE_*` vars to tests.            |
+
+### Parallelism model
+
+- **File-level:** parallel. Each `.test.ts` file runs in its own worker, which means each has its own module-level state (including the `ports: number[]` tracker in `testWithRpc.ts:80`). Workers do not share a port list, but `get-port` asks the OS for a free port, so real collisions are rare.
+- **Test-level (inside a file):** serial. Each `testWithRpc(...)` inside a file waits for the previous one to tear down before the next starts. That means **within one file, there is never more than one Anvil/Alto/paymaster trio alive at once**.
+
+Combined: at any instant, concurrency ≈ number of `.test.ts` files currently in flight. With Vitest's default worker count (≈ CPU cores), you typically have 4–8 parallel stacks.
+
+### Why `hookTimeout` is 45s
+
+`testWithRpc` setup does, in order:
+1. Allocate 3 free ports (ms).
+2. Start Anvil (~1–3s cold).
+3. Call `setupContracts(anvilRpc)` which issues **~80+ transactions** to the deterministic deployer and a few impersonation + `setCode` calls. With all txns batched via `Promise.all`, this typically lands in 2–8s but can spike.
+4. Start Alto (subprocess, waits for `"Server listening at"` message; ~2–5s).
+5. Start the paymaster (Fastify boot; ~1s).
+
+On a slow machine or noisy CI runner, cumulative setup > 30s is possible; 45s is the margin.
+
+## File layout
+
+Tests are **colocated with source code**, as `<name>.test.ts` next to `<name>.ts`:
+
+```
+packages/permissionless/
+├── accounts/
+│   ├── decodeCalls.test.ts
+│   └── safe/signUserOperation.test.ts
+├── actions/
+│   ├── erc7579/       ← 8 tests (install/uninstall/supports/etc.)
+│   ├── pimlico/       ← 5 tests (gas price, status, sponsor, quotes, …)
+│   ├── public/        ← 2 tests (getAccountNonce, getSenderAddress)
+│   └── smartAccount/  ← 5 tests (sendTransaction, sendCalls, signMessage, …)
+├── experimental/pimlico/utils/
+│   └── prepareUserOperationForErc20Paymaster.test.ts
+└── utils/             ← 10 tests (nonce enc/dec, hashing, overrides, etc.)
+```
+
+Non-exhaustive — see `packages/permissionless/**/*.test.ts` for the full set.
+
+### The `permissionless-test` package
+
+`packages/permissionless-test/` is a **private** workspace package (`"private": true` in its `package.json`) that holds:
+
+| Directory / file                          | Purpose                                                                 |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `src/testWithRpc.ts`                      | The `testWithRpc` fixture — starts/stops anvil + alto + paymaster.      |
+| `src/utils.ts`                            | All viem/Pimlico/smart-account helpers. Re-read this often.             |
+| `src/types.ts`                            | `AAParamType<entryPointVersion>`.                                       |
+| `mock-aa-infra/alto/instance.ts`          | `alto(...)` prool instance factory.                                     |
+| `mock-aa-infra/alto/index.ts`             | `setupContracts(rpc)` — deploys ~everything via the deterministic deployer. |
+| `mock-aa-infra/alto/constants/core.ts`    | EntryPoint v0.6/0.7/0.8 creation-call bytecode.                         |
+| `mock-aa-infra/alto/constants/accounts/*` | Per-account-family creation-call bytecode (safe, kernel, light, …).     |
+
+It is imported from test files by **relative path** (e.g. `"../../../permissionless-test/src/testWithRpc"`), not by package name.
+
+### The `mock-paymaster` package
+
+`packages/mock-paymaster/` is a local workspace dependency that exports `paymaster(...)` — a prool instance wrapping a Fastify server. It handles ERC-4337 paymaster RPC methods (`pm_sponsorUserOperation`, `pimlico_getTokenQuotes`, …) against the local anvil and alto. See [03-infrastructure.md § Mock paymaster](./03-infrastructure.md#mock-paymaster).
+
+## File-path cheat sheet
+
+| You want to…                             | Open                                                                      |
+| ---------------------------------------- | ------------------------------------------------------------------------- |
+| Change how tests are discovered / timed out | `packages/permissionless/vitest.config.ts`                                |
+| Change the per-test setup/teardown       | `packages/permissionless-test/src/testWithRpc.ts`                         |
+| Add a new viem client helper             | `packages/permissionless-test/src/utils.ts`                               |
+| Add a new smart account type             | `packages/permissionless-test/src/utils.ts` + `mock-aa-infra/alto/constants/accounts/` + `mock-aa-infra/alto/index.ts` |
+| Change how the bundler is started        | `packages/permissionless-test/mock-aa-infra/alto/instance.ts`             |
+| Change the mock paymaster's behaviour    | `packages/mock-paymaster/`                                                |
+| Change CI flags / env vars               | `.github/workflows/on-pull-request.yml`                                   |
+
+→ Next: [02-lifecycle.md](./02-lifecycle.md)

--- a/docs/testing/02-lifecycle.md
+++ b/docs/testing/02-lifecycle.md
@@ -1,0 +1,187 @@
+# 02 — Per-test lifecycle
+
+This document walks through exactly what happens before, during, and after a single test body executes. The protagonist is the `testWithRpc` fixture in `packages/permissionless-test/src/testWithRpc.ts`.
+
+## The fixture
+
+`testWithRpc` is Vitest's `test.extend(...)` applied to produce a custom `test` function that provides a `rpc` fixture. Test files import it like:
+
+```ts
+import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
+
+testWithRpc("my test", async ({ rpc }) => {
+    const { anvilRpc, altoRpc, paymasterRpc } = rpc
+    // ...
+})
+```
+
+The fixture definition (`packages/permissionless-test/src/testWithRpc.ts:80`):
+
+```ts
+let ports: number[] = []
+
+export const testWithRpc = test.extend<{
+    rpc: {
+        anvilRpc: string
+        altoRpc: string
+        paymasterRpc: string
+    }
+}>({
+    rpc: async ({}, use) => {
+        const altoPort = await getPort({ exclude: ports })
+        ports.push(altoPort)
+        const paymasterPort = await getPort({ exclude: ports })
+        ports.push(paymasterPort)
+        const anvilPort = await getPort({ exclude: ports })
+        ports.push(anvilPort)
+
+        const anvilRpc     = `http://localhost:${anvilPort}`
+        const altoRpc      = `http://localhost:${altoPort}`
+        const paymasterRpc = `http://localhost:${paymasterPort}`
+
+        const instances = await getInstances({ anvilPort, altoPort, paymasterPort })
+
+        await use({ anvilRpc, altoRpc, paymasterRpc })
+
+        await Promise.all(instances.map((instance) => instance.stop()))
+        ports = ports.filter(
+            (port) => port !== altoPort || port !== anvilPort || port !== paymasterPort
+        )
+    }
+})
+```
+
+Three things to notice:
+
+1. The whole fixture is a single async function with a single `use(...)` call in the middle. Everything before `use` is **setup**; everything after is **teardown**. Vitest awaits setup, runs the test body (which receives the argument passed to `use`), then awaits teardown.
+2. `ports` is a **module-level** `let` array. Each Vitest worker has its own module scope, so this tracker is per-worker.
+3. `getInstances(...)` (defined in the same file, `testWithRpc.ts:14`) is where the three processes are actually spawned — covered in [03-infrastructure.md](./03-infrastructure.md).
+
+## Port allocation
+
+`get-port` is used three times in a row, each excluding the previously-allocated ports from the search:
+
+```ts
+const altoPort      = await getPort({ exclude: ports })
+ports.push(altoPort)
+const paymasterPort = await getPort({ exclude: ports })
+ports.push(paymasterPort)
+const anvilPort     = await getPort({ exclude: ports })
+ports.push(anvilPort)
+```
+
+`get-port` asks the OS for an available port (by briefly binding to port `0`), so the main source of conflict is an **already-in-use Vitest fixture in the same worker** — which the `exclude` list handles.
+
+### Why `exclude` matters
+
+Without it, the second call could return the port just allocated by the first (since nothing is listening on it yet — the Anvil process hasn't started). Pushing each port onto the tracker and passing `exclude: ports` forces `get-port` to skip them.
+
+### The teardown filter quirk
+
+The filter on teardown (`testWithRpc.ts:121`) is:
+
+```ts
+ports = ports.filter(
+    (port) => port !== altoPort || port !== anvilPort || port !== paymasterPort
+)
+```
+
+With three distinct ports, for any element `p` in the array, at most **one** of `p !== altoPort`, `p !== anvilPort`, `p !== paymasterPort` is false — the other two are true, so the `||` short-circuits to true. Every element is kept. In other words, **ports are never removed from the tracker**.
+
+In practice this is harmless because:
+- Each Vitest worker serialises tests within a file, so the tracker only grows by 3 per test in that worker.
+- `get-port` still asks the OS for a genuinely free port each call; the `exclude` list just adds ports to avoid. Past ports that are now closed don't block the OS from reusing them for later tests — but they do grow the `exclude` array.
+
+If you touch this file, a correct filter would be `p !== altoPort && p !== anvilPort && p !== paymasterPort`. This doc describes current behaviour; any change is out of scope here.
+
+## Setup sequence
+
+`getInstances` (`testWithRpc.ts:14–78`) runs this order — and the order matters:
+
+```
+┌── getInstances ──────────────────────────────────────────────────┐
+│                                                                  │
+│  1. Build AnvilInstance   (forked if VITE_FORK_RPC_URL is set)   │
+│  2. Build AltoInstance    (rpcUrl = http://localhost:anvilPort)  │
+│  3. Build paymasterInstance (anvilRpc + altoRpc + port)          │
+│  4. await anvilInstance.start()                                  │
+│  5. if (!forkUrl) await setupContracts(anvilRpc)                 │
+│  6. await altoInstance.start()                                   │
+│  7. await paymasterInstance.start()                              │
+│  8. return [anvilInstance, altoInstance, paymasterInstance]      │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Why this order:
+
+- **Anvil must be up before contracts are deployed** — `setupContracts` issues real JSON-RPC transactions.
+- **Contracts must exist before Alto starts.** Alto queries the EntryPoint and simulation contracts on boot; if they don't exist yet its RPC will respond with errors when the test tries to `eth_supportedEntryPoints`, etc.
+- **Alto must be up before the paymaster starts.** The paymaster calls Alto during setup and during sponsorship. See `packages/mock-paymaster/index.ts:33` where `setup({ anvilRpc, paymasterSigner })` runs before Fastify starts listening.
+- If `VITE_FORK_RPC_URL` is set, `setupContracts` is **skipped** — the forked chain already contains all the deployed contracts. See [06-ci-and-running.md § Fork mode](./06-ci-and-running.md#fork-mode).
+
+Contract deployment details are in [04-contracts.md](./04-contracts.md). Process-level details (how `prool` spawns subprocesses, what readiness signals each uses) are in [03-infrastructure.md](./03-infrastructure.md).
+
+## Teardown sequence
+
+After the test body finishes (whether it passed, failed, or threw):
+
+```ts
+await Promise.all(instances.map((instance) => instance.stop()))
+```
+
+- All three instances are stopped in parallel.
+- `anvilInstance.stop()` and `altoInstance.stop()` kill their subprocesses (via `prool`).
+- `paymasterInstance.stop()` calls `app.close()` on the Fastify server (`packages/mock-paymaster/index.ts:57`).
+- After this, the port-tracker update runs (and as noted above, leaves the tracker unchanged).
+
+If the test body throws **before** `use`'s callback resolves, Vitest still runs teardown. If the teardown itself throws, Vitest reports it as a setup/teardown failure on the test.
+
+## State isolation guarantees
+
+Because every test gets a fresh trio of processes:
+
+| Concern                   | Guarantee                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| Chain state               | Fresh genesis (unless fork mode). Block number resets.                                     |
+| Account nonces            | Anvil account `0xac097…` and the Rhinestone/Kernel/Alchemy impersonated addresses all start from 0 (or forked nonce). |
+| Deployed contract state   | All ERC-4337 contracts are newly deployed → storage is exactly what `setupContracts` writes. |
+| Smart-account deployments | Every test creates its own smart account (by private key); counterfactual addresses differ  per-test because `privateKey` defaults to `generatePrivateKey()` in most helpers. |
+| Bundler mempool           | Fresh Alto, empty mempool.                                                                 |
+| Paymaster nonces          | Fresh wallet tied to the paymaster private key `0xbbbb…bbbb`.                              |
+| Ports                     | Distinct for every concurrent test.                                                        |
+
+**Cross-test interference is impossible by construction** — there is no shared mutable state between tests, because there are no shared processes.
+
+## Interaction with `describe.each`
+
+Many tests use `describe.each(getCoreSmartAccounts())` to matrix across every smart-account type. For example, `packages/permissionless/actions/smartAccount/sendTransaction.test.ts:14`:
+
+```ts
+describe.each(getCoreSmartAccounts())(
+    "sendTransaction $name",
+    ({ getSmartAccountClient, supportsEntryPointV06, supportsEntryPointV07, supportsEntryPointV08, isEip7702Compliant }) => {
+        testWithRpc.skipIf(!supportsEntryPointV06)("sendTransaction_v06", async ({ rpc }) => {
+            const smartClient = await getSmartAccountClient({ entryPoint: { version: "0.6" }, ...rpc })
+            // ...
+        })
+        // ...
+    }
+)
+```
+
+Each generated `testWithRpc(...)` call gets its **own** `getInstances` call, not a shared one. So `sendTransaction Safe / sendTransaction_v06` and `sendTransaction Kernel / sendTransaction_v06` each spawn their own anvil/alto/paymaster trio. This is fine because tests within one file run serially ([see 01-architecture.md § Parallelism model](./01-architecture.md#parallelism-model)).
+
+`testWithRpc.skipIf(!supportsEntryPointV06)` is a thin wrapper around Vitest's `test.skipIf`: it short-circuits the whole fixture when the predicate is true, so skipped tests don't pay the setup cost.
+
+## What runs on each port
+
+| Port           | Process              | Primary RPC surface                                                              |
+| -------------- | -------------------- | -------------------------------------------------------------------------------- |
+| `anvilPort`    | Anvil (via `prool`)  | Standard JSON-RPC (`eth_*`, `anvil_*` cheat codes).                              |
+| `altoPort`     | Alto bundler         | ERC-4337 bundler methods (`eth_sendUserOperation`, `eth_estimateUserOperationGas`, `pimlico_*`, etc.). |
+| `paymasterPort`| Fastify mock paymaster | `POST /` (RPC handler: `pm_sponsorUserOperation`, `pimlico_getTokenQuotes`, …) and `GET /ping` (health). |
+
+The helper functions that understand these URLs are all in `packages/permissionless-test/src/utils.ts` — covered in [05-clients-accounts.md](./05-clients-accounts.md).
+
+→ Next: [03-infrastructure.md](./03-infrastructure.md)

--- a/docs/testing/03-infrastructure.md
+++ b/docs/testing/03-infrastructure.md
@@ -1,0 +1,256 @@
+# 03 — Infrastructure (Anvil, Alto, mock paymaster)
+
+Three processes are spawned per test. This document describes how each is configured, how they are started and stopped, and what guarantees each provides.
+
+All three are built on [`prool`](https://github.com/wevm/prool), a small library for orchestrating local dev processes (it provides `defineInstance` + an `execa`-based process manager). Each instance exposes `.start()` and `.stop()`.
+
+## Anvil
+
+Spawned in `packages/permissionless-test/src/testWithRpc.ts:29` via `prool/instances`'s built-in `anvil` factory:
+
+```ts
+import { anvil } from "prool/instances"
+
+const anvilInstance = forkUrl
+    ? anvil({
+          chainId: foundry.id,
+          port: anvilPort,
+          hardfork: "Prague",
+          forkUrl
+      })
+    : anvil({
+          chainId: foundry.id,
+          hardfork: "Prague",
+          port: anvilPort
+      })
+```
+
+| Setting       | Value                                               | Notes                                                                                              |
+| ------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `chainId`     | `foundry.id` (`31337`)                              | Same chainId whether forked or not. All viem clients use `chain: foundry`.                         |
+| `hardfork`    | `"Prague"`                                          | Pinned to Prague for consistent behavior (EIP-7702 is Prague-era; some tests rely on its opcodes). |
+| `port`        | `anvilPort` (dynamic)                               | See [02-lifecycle.md § Port allocation](./02-lifecycle.md#port-allocation).                        |
+| `forkUrl`     | `process.env.VITE_FORK_RPC_URL` (optional)          | If set, Anvil boots as a fork of that chain at its tip.                                            |
+
+### Default funded account
+
+Anvil ships with 10 pre-funded accounts from the mnemonic `test test test test test test test test test test test junk`. The tests care about index 0 in particular:
+
+- Private key: `0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`
+- Address:     `0xf39Fd6e51aad88F6F4ce6aB8827279cfFFb92266`
+
+This key is used:
+
+1. As the default signer for `walletClient` in `setupContracts` (`mock-aa-infra/alto/index.ts:107`).
+2. As Alto's `executorPrivateKeys[0]` and `utilityPrivateKey` (`testWithRpc.ts:22`).
+3. Indirectly via `getAnvilWalletClient({ addressIndex: 0 })` helper.
+
+### Fork mode
+
+If `VITE_FORK_RPC_URL` is set in `.env.test` (or process env), Anvil starts as a fork of that URL. The fixture also **skips** `setupContracts(anvilRpc)` (`testWithRpc.ts:70`) because a live network already has the EntryPoints, factories, etc. deployed at their deterministic addresses.
+
+See [06-ci-and-running.md § Fork mode](./06-ci-and-running.md#fork-mode) for usage.
+
+## Alto bundler
+
+The Alto wrapper lives in `packages/permissionless-test/mock-aa-infra/alto/instance.ts`. It is a **custom `prool` instance** (not shipped by `prool` itself) built with `defineInstance` + `execa`.
+
+The test fixture constructs Alto with (`testWithRpc.ts:42`):
+
+```ts
+const altoInstance = alto({
+    entrypoints: [
+        entryPoint06Address,
+        entryPoint07Address,
+        entryPoint08Address
+    ],
+    rpcUrl: anvilRpc,
+    executorPrivateKeys: [anvilPrivateKey],
+    safeMode: false,
+    port: altoPort,
+    utilityPrivateKey: anvilPrivateKey
+})
+```
+
+| Setting                  | Value                                      | Why                                                                                                   |
+| ------------------------ | ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `entrypoints`            | `[v0.6, v0.7, v0.8]`                       | Tests exercise all three EntryPoint versions, so Alto must register all three.                        |
+| `rpcUrl`                 | `http://localhost:${anvilPort}`            | The chain Alto watches/submits to.                                                                    |
+| `executorPrivateKeys`    | `[anvilPrivateKey]`                        | The account(s) that sign handleOps bundle transactions.                                               |
+| `utilityPrivateKey`      | `anvilPrivateKey`                          | Alto's utility wallet (refills executors, deploys supporting contracts).                              |
+| `safeMode`               | `false`                                    | Skips ERC-4337 validity-rule enforcement. Test-only convenience; do not copy into production configs. |
+| `port`                   | `altoPort`                                 | Dynamic per test.                                                                                     |
+
+Using the anvil account 0 key for **both** executor and utility is fine: that account is funded with 10,000 ETH by Anvil, so gas costs are unbounded.
+
+### How `alto` is spawned
+
+From `packages/permissionless-test/mock-aa-infra/alto/instance.ts:244`:
+
+```ts
+export const alto = defineInstance((parameters?: AltoParameters) => {
+    const { ...args } = (parameters || {}) as AltoParameters
+    const name = "alto"
+    const process = execa({ name })
+
+    return {
+        _internal: { args, get process() { return process._internal.process } },
+        host: "localhost",
+        name,
+        port: args.port ?? 3000,
+
+        async start({ port = args.port ?? 3000 }, options) {
+            const binary = (() => {
+                if (args.binary) return [args.binary]
+                const libPath =
+                    "resolve" in import.meta
+                        ? import.meta.resolve("@pimlico/alto").split("file:")[1]
+                        : require.resolve("@pimlico/alto")
+                return ["node", resolve(libPath, "../cli/alto.js")]
+            })()
+
+            await process.start(
+                ($) => $`${binary} ${toArgs({ port, ...args })}`,
+                {
+                    ...options,
+                    // Resolve when the process is listening via a "Server listening at" message.
+                    resolver({ process, reject, resolve }) {
+                        process.stdout.on("data", (data) => {
+                            const message = data.toString()
+                            if (message.includes("Server listening at"))
+                                resolve()
+                        })
+                    }
+                }
+            )
+        },
+
+        async stop() { await process.stop() }
+    }
+})
+```
+
+Key observations:
+
+1. The binary is resolved from the `@pimlico/alto` npm package's `cli/alto.js` entrypoint. It runs via `node`, not a standalone binary.
+2. Arguments are built by `toArgs(...)` from `prool` — it turns the `AltoParameters` object into a CLI argument list.
+3. **Readiness signal: the literal string `"Server listening at"` on stdout.** The `start()` promise only resolves once this appears, which means tests can safely make RPC calls against Alto as soon as the fixture's `await use(...)` begins.
+4. No stderr-based rejection is wired up (the line `process.stderr.on('data', reject)` is commented out). A crashing Alto will hang until Vitest's `hookTimeout` (45s) fires.
+
+`AltoParameters` (`instance.ts:6–227`) has ~40 fields mirroring Alto's CLI. The test fixture only sets the handful shown above; everything else uses Alto's defaults.
+
+### Readiness helper
+
+Although `prool` already waits for `"Server listening at"`, there's also an independent readiness loop for tests that want belt-and-braces (`packages/permissionless-test/src/utils.ts:61`):
+
+```ts
+export const ensureBundlerIsReady = async ({ altoRpc, anvilRpc }) => {
+    const bundlerClient = getBundlerClient({ altoRpc, anvilRpc, entryPoint: { version: "0.6" } })
+    while (true) {
+        try {
+            await bundlerClient.getChainId()
+            return
+        } catch {
+            await new Promise((resolve) => setTimeout(resolve, 1000))
+        }
+    }
+}
+```
+
+It polls `getChainId()` against Alto until it responds. Most tests don't need this because the fixture already waits for Alto to start.
+
+## Mock paymaster
+
+The mock paymaster is in its own workspace package `packages/mock-paymaster/`. Entry file `packages/mock-paymaster/index.ts:10`:
+
+```ts
+export const paymaster = defineInstance(
+    ({ anvilRpc, altoRpc, port: _port, host: _host = "localhost" }) => {
+        const app = Fastify({})
+        return {
+            _internal: {},
+            host: _host,
+            port: _port,
+            name: "mock-paymaster",
+            start: async ({ port = _port }) => {
+                const paymasterSigner = createWalletClient({
+                    chain: await getChain(anvilRpc),
+                    account: privateKeyToAccount(
+                        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    ),
+                    transport: http(anvilRpc)
+                })
+
+                await setup({ anvilRpc, paymasterSigner: paymasterSigner.account.address })
+
+                app.register(cors, { origin: "*", methods: ["POST", "GET", "OPTIONS"] })
+
+                const rpcHandler = createRpcHandler({ altoRpc, anvilRpc, paymasterSigner })
+                app.post("/", {}, rpcHandler)
+                app.get("/ping", async (_request, reply) => reply.code(200).send({ message: "pong" }))
+
+                await app.listen({ host: _host, port })
+            },
+            stop: async () => { app.close() }
+        }
+    }
+)
+```
+
+### Endpoints
+
+| Method | Path    | Purpose                                                                                            |
+| ------ | ------- | -------------------------------------------------------------------------------------------------- |
+| `POST` | `/`     | JSON-RPC handler. Methods include `pm_sponsorUserOperation`, Pimlico ERC-20 quotes, etc. See `packages/mock-paymaster/relay.ts` and siblings. |
+| `GET`  | `/ping` | Health check. Returns `{ "message": "pong" }`. Used by `ensurePaymasterIsReady`.                   |
+
+### Paymaster signer
+
+The paymaster uses a fixed key: `0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`. Its Ethereum address is constant and well-known; the paymaster's `setup(...)` call (from `packages/mock-paymaster/setup.ts`) is responsible for deploying a paymaster contract owned by this key against the local anvil, funding it, etc.
+
+### Readiness helper
+
+Unlike Alto, `paymaster.start()` does **not** have a stdout-based readiness signal — `app.listen(...)` already awaits server-start, so when `paymasterInstance.start()` resolves, the server is accepting connections. There is still a polling helper in `packages/permissionless-test/src/utils.ts:83`:
+
+```ts
+export const ensurePaymasterIsReady = async () => {
+    while (true) {
+        try {
+            const res = await fetch(`${PAYMASTER_RPC}/ping`)
+            const data = await res.json()
+            if (data.message !== "pong") throw new Error("nope")
+            return
+        } catch {
+            await new Promise((resolve) => setTimeout(resolve, 1000))
+        }
+    }
+}
+```
+
+**Caveat:** this helper uses the constant `PAYMASTER_RPC = "http://localhost:3000"` (`utils.ts:59`), **not** the dynamically-allocated `paymasterRpc` from the fixture. So it only works if a paymaster happens to be listening on port 3000. Prefer relying on the fixture's guarantee that the server is live by the time the test body runs.
+
+## Startup ordering & dependencies
+
+```
+┌──────────────┐     ┌──────────────┐     ┌─────────────────┐
+│   Anvil      │ ◄── │   Alto       │ ◄── │  Mock paymaster │
+│ anvilPort    │     │   altoPort   │     │  paymasterPort  │
+└──────────────┘     └──────────────┘     └─────────────────┘
+       ▲                   ▲ ▲                 ▲
+       │                   │ └─────────────────┤
+       │                   │                   │
+       │                   │                   └── paymaster.start() calls
+       │                   │                       setup(anvilRpc, signerAddr)
+       │                   │                       and later serves requests
+       │                   │                       that hit altoRpc for RPC fanout
+       │                   │
+       │                   └── alto boots and queries anvil for chainId,
+       │                       registered entrypoints, etc.
+       │
+       └── setupContracts(anvilRpc): deploys EntryPoints v0.6/0.7/0.8 and
+           every smart-account factory before Alto boots.
+```
+
+Practical upshot: if you ever rearrange `getInstances`, keep the order **anvil → contracts → alto → paymaster**. Swapping any two will cause one of the processes to make RPC calls against a counterparty that doesn't exist or isn't ready yet.
+
+→ Next: [04-contracts.md](./04-contracts.md)

--- a/docs/testing/04-contracts.md
+++ b/docs/testing/04-contracts.md
@@ -1,0 +1,157 @@
+# 04 — Contract injection
+
+After Anvil boots but before Alto starts, the fixture calls `setupContracts(anvilRpc)` from `packages/permissionless-test/mock-aa-infra/alto/index.ts:105`. This function deploys every ERC-4337 contract the tests need — around 60+ contracts in total — using **deterministic deployers**, so they end up at the same addresses every time.
+
+Skipped entirely when `VITE_FORK_RPC_URL` is set (see [03-infrastructure.md § Fork mode](./03-infrastructure.md#fork-mode)).
+
+## The deployment strategy
+
+`setupContracts` uses three mechanisms, in combination:
+
+### 1. Deterministic Deployer (Arachnid's `0x4e59b44847…`)
+
+The Arachnid proxy exists on mainnet at `0x4e59b44847b379578588920ca78fbf26c0b4956c` and is preinstalled on Anvil. A transaction to this address with `data = <salt (32 bytes)> + <initcode>` performs a CREATE2 with `msg.sender = 0x4e59…` → the resulting contract address is a deterministic function of `(salt, initcode)`. The pre-packaged creation-call bytes are stored as `*_CREATECALL` constants and sent as-is.
+
+`packages/permissionless-test/mock-aa-infra/alto/index.ts:87`:
+
+```ts
+const DETERMINISTIC_DEPLOYER = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+```
+
+Typical usage (`index.ts:132`):
+
+```ts
+walletClient.sendTransaction({
+    to: DETERMINISTIC_DEPLOYER,
+    data: ENTRY_POINT_V08_CREATECALL,
+    gas: 15_000_000n,
+    nonce: nonce++
+}),
+```
+
+### 2. Safe Singleton Factory (`0x914d7Fec…`)
+
+Safe's equivalent of Arachnid, at `0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7`. It isn't native to Anvil, so its bytecode is injected via `anvil_setCode` cheat code **before** it's used (`index.ts:127`):
+
+```ts
+await anvilClient.setCode({
+    address: SAFE_SINGLETON_FACTORY,
+    bytecode: SAFE_SINGLETON_FACTORY_BYTECODE
+})
+```
+
+Then transactions to this address deploy Safe-family contracts deterministically.
+
+### 3. Biconomy Singleton Factory (`0x988C…`)
+
+Same pattern — Biconomy has its own singleton factory (`0x988C135a1049Ce61730724afD342fb7C56CD2776`). Its bytecode is also injected via `setCode` (`index.ts:498`):
+
+```ts
+await anvilClient.setCode({
+    address: BICONOMY_SINGLETON_FACTORY,
+    bytecode: BICONOMY_SINGLETON_FACTORY_BYTECODE
+})
+```
+
+### 4. Impersonation
+
+A few contracts (Kernel factories, the LightAccount v2 factory's owner-only init, the Rhinestone attester's registration/attestation calls) require calls from specific privileged addresses that the tests don't own keys to. The function uses `anvil_impersonateAccount` + `anvil_setBalance` cheat codes to pretend to be those addresses:
+
+```ts
+const rhinestoneAttester = "0x000000333034E9f539ce08819E12c1b8Cb29084d"
+await anvilClient.setBalance({ address: rhinestoneAttester, value: parseEther("100") })
+await anvilClient.impersonateAccount({ address: rhinestoneAttester })
+// ... sendTransaction({ account: rhinestoneAttester, ... })
+await anvilClient.stopImpersonatingAccount({ address: rhinestoneAttester })
+```
+
+Used for:
+- `0x000000333034E9f539ce08819E12c1b8Cb29084d` — Rhinestone attester for ERC-7579 module schema/resolver/attestation (`index.ts:562–603`).
+- `0x9775137314fE595c943712B0b336327dfa80aE8A` — Kernel factory owner (calls `setImplementation` on Kernel v0.6 + v0.7 factories, `index.ts:606–687`).
+- `0xDdF32240B4ca3184De7EC8f0D5Aba27dEc8B7A5C` — Alchemy LightAccount client owner, used to configure LightAccount v2.0.0 (`index.ts:690–709`).
+
+## Phases
+
+`setupContracts` is organised in roughly four phases:
+
+1. **Cheat-code prelude.** Set the Safe singleton factory's bytecode.
+2. **Batch deploy (first `Promise.all`).** ~50 transactions deploying EntryPoints, Simple/Safe/Kernel/Light/Trust/Thirdweb/Nexus-bootstrap factories and validators. All sent in parallel with explicit incrementing nonces so Anvil can order them.
+3. **Batch deploy (second `Promise.all`).** ~10 more transactions for Safe proxy factory + singleton + multiSend, Etherspot, Safe 7579 module/launchpad.
+4. **Biconomy factory seed + Biconomy/Nexus deploys.** Inject Biconomy singleton factory bytecode, then another parallel batch of 8 deploys through it.
+5. **Privileged registrations.** Rhinestone attester registers the ERC-7579 test-module schema/resolver/attestation; Kernel factory owner registers all Kernel implementations; Alchemy owner initializes LightAccount v2.0.0.
+6. **`verifyDeployed(...)`.** Reads bytecode at every expected address and `process.exit(1)` if any is missing — fast fail rather than a confusing test error later.
+
+The final verified address list is in `index.ts:711–782` and functions as a self-documenting manifest of what gets deployed.
+
+## Everything that gets deployed
+
+Grouped by account family. Source constants live in `packages/permissionless-test/mock-aa-infra/alto/constants/`.
+
+| Category                | Contracts (deterministic addresses)                                                                                                                                                                                                                      | Source constants file            |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| EntryPoints             | v0.6 `0x5FF1…2789`, v0.7 `0x0000…0032`, v0.8 `0x4337…f108`                                                                                                                                                                                                 | `constants/core.ts`              |
+| Deterministic deployers | Arachnid `0x4e59…956c` (native to Anvil), Safe singleton factory `0x914d…43d7`, Biconomy singleton factory `0x988C…2776`                                                                                                                                   | `constants/core.ts`              |
+| Simple Account          | v0.6 factory `0x9406…6454`, v0.7 factory `0x91E6…8985`, v0.8 factory `0x13E9…5944` + v0.8 impl `0xe6Ca…555B`                                                                                                                                                | `constants/accounts/simple.ts`   |
+| Safe (ERC-4337 modules) | v0.6 module setup `0x8EcD…34eb` + module `0xa581…4037`, v0.7 module setup `0x2dd6…5b47` + module `0x75cf…c226`, proxy factory `0x4e1D…ec67`, singleton `0x4167…461a`, multiSend `0x3886…3526`, multiSend-call-only `0x9641…2e02`, Safe 1.5.0 proxy/singleton/send/multisend (`0x14F2…5e7b`, `0xFf51…a44b`, `0x2185…7eB7`, `0xA83c…1836`) | `constants/accounts/safe.ts`     |
+| Safe + ERC-7579         | 7579 module `0x7579…0002`, 7579 launchpad `0x7579…00ff`, registry `0x0000…51B2` + schema/resolver/proxies                                                                                                                                                  | `constants/accounts/safe.ts`     |
+| Kernel v0.6 (v2.x)      | Account logic v2.1/2.2/2.3/2.4, ECDSA validator v2.2, factory `0x5de4…Ae3`                                                                                                                                                                                 | `constants/accounts/kernel.ts`   |
+| Kernel v0.7 (v3.x)      | Account logic v3.0/3.1/3.2/3.3, factories for each, meta-factory `0xd703…42d5`, ECDSA validators v3.0/v3.1, WebAuthn validator v3.1                                                                                                                         | `constants/accounts/kernel.ts`   |
+| LightAccount            | v1.1.0 factory `0x0000…0D20` + impl `0xae8c…3cba`, v2.0.0 factory `0x0000…BC24` + impl `0x8E8e…13C7`                                                                                                                                                         | `constants/accounts/light.ts`    |
+| Biconomy                | ECDSA Ownership Registry module `0x0000…Ea8e`, Account logic v2 `0x0000…423ac`, factory `0x0000…34F5`, default fallback handler `0x0bBa…83C1`                                                                                                              | `constants/accounts/biconomy.ts` |
+| Trust                   | Factory `0x729c…272a`, diamond facets (AccountFacet, DiamondCut, DiamondLoupe, TokenReceiver), Secp256k1VerificationFacet, DefaultFallbackHandler                                                                                                         | `constants/accounts/trust.ts`    |
+| Thirdweb                | v0.6 factory `0x85e2…DF00`, v0.7 factory `0x4be0…DCEB`                                                                                                                                                                                                     | `constants/accounts/thirdweb.ts` |
+| Etherspot               | Factory `0x2A40…B451`, bootstrap `0x0D51…C8AA`, multiple-owner ECDSA validator `0x0740…1906`, implementation `0x339e…A7b0`                                                                                                                                 | `constants/accounts/etherspot.ts`|
+| Nexus                   | K1 validator `0x0000…1E8f`, K1 validator factory `0x0000…DB55`, account impl `0x0000…58f7`, account bootstrapper `0x0000…73d3`, bootstrap lib `0x6c77…39c0`                                                                                                  | `constants/accounts/nexus.ts`    |
+| ERC-7579 test module    | `0x4Fd8…8354` (registered + attested by the Rhinestone attester)                                                                                                                                                                                           | `constants/core.ts`              |
+
+The authoritative list with every address is in `verifyDeployed(client, [...])` at `mock-aa-infra/alto/index.ts:711–782`. If this doc and that list disagree, the code wins.
+
+## Why pre-computed creation calls?
+
+Each `*_CREATECALL` constant is literally a hex string: `<salt (32 bytes)><initcode>`. These aren't re-derived from Solidity source at test time — they are checked-in pre-computed values. Benefits:
+
+- **Hermetic.** Tests don't need `forge build` / `solc` available on the developer's machine.
+- **Deterministic addresses.** Because both salt and initcode are frozen, every test run produces the same contract addresses. Viem clients and generated `entryPoint06Address` / `entryPoint07Address` / `entryPoint08Address` constants from `viem/account-abstraction` match.
+- **Fast.** ~80 `sendTransaction` calls against a local Anvil complete in a couple of seconds.
+
+Downside: updating a contract means regenerating its creation-call bytes. There is (at time of writing) no in-repo script to regenerate them — new creation-calls are produced outside the repo and checked in as hex.
+
+## Adding a new contract
+
+To add a new contract to every test's pre-deployed set:
+
+1. **Produce the creation-call bytes.** Take the contract's creation bytecode, prepend a 32-byte salt (by convention, zeros or a project-specific constant), and store it as a `0x…` hex string in `packages/permissionless-test/mock-aa-infra/alto/constants/accounts/<family>.ts` (or `core.ts` for shared infra).
+
+   ```ts
+   export const MYNEWFACTORY_V1_CREATECALL = "0x<salt><initcode>" as const
+   ```
+
+   Re-export it from `constants/index.ts`.
+
+2. **Add a deploy call** in `setupContracts` at `mock-aa-infra/alto/index.ts`. Choose which batch to join (first or second `Promise.all`) based on whether it has dependencies on anything in the first batch. If the contract requires the Safe or Biconomy singleton factory, use that as `to`; otherwise use `DETERMINISTIC_DEPLOYER`.
+
+   ```ts
+   walletClient.sendTransaction({
+       to: DETERMINISTIC_DEPLOYER,
+       data: MYNEWFACTORY_V1_CREATECALL,
+       gas: 15_000_000n,
+       nonce: nonce++
+   }),
+   ```
+
+3. **Add a post-deployment privileged step** if needed. If your contract requires calls from a specific owner address before it's usable (like Kernel factories), use the `impersonateAccount` / `stopImpersonatingAccount` / `setBalance` pattern already in the file.
+
+4. **Add the expected address to `verifyDeployed`** at the bottom of `setupContracts` so boot fails loudly if deployment silently fails.
+
+5. **Add a helper** in `packages/permissionless-test/src/utils.ts` for creating client/account instances — see [05-clients-accounts.md § Wiring a new account helper](./05-clients-accounts.md#wiring-a-new-account-helper).
+
+6. **Register it with `getCoreSmartAccounts()`** if it should participate in the matrix tests.
+
+## Things that will surprise you
+
+- **All transactions share one nonce counter.** `setupContracts` fetches the starting nonce once (`const nonce = await client.getTransactionCount(...)`) then increments it locally for every `sendTransaction` call. All calls in a `Promise.all` batch are created synchronously, so the nonces are correct — but if you refactor to make batch creation async, you must serialize nonce assignment.
+- **`gas: 15_000_000n` is hardcoded everywhere.** Anvil's block gas limit is 30M by default; 15M per txn is ample for creation calls. Don't reduce this casually; some initcodes are large.
+- **Batches run in parallel but `Promise.all`.** If *any* transaction fails, the entire setup aborts. The logs will show the failing address because `verifyDeployed` calls `process.exit(1)` and prints the missing address.
+- **The Rhinestone attester impersonation injects ~2KB of call data per registration.** These are real calldata blobs for module schema/resolver/attestation registrations; if the upstream registry changes its ABI, these hex strings will need to be regenerated.
+
+→ Next: [05-clients-accounts.md](./05-clients-accounts.md)

--- a/docs/testing/05-clients-accounts.md
+++ b/docs/testing/05-clients-accounts.md
@@ -1,0 +1,381 @@
+# 05 — Clients & account helpers
+
+Every viem client and smart-account factory used in tests lives in one file: `packages/permissionless-test/src/utils.ts` (1,091 lines). This document catalogues them, explains how they compose, and walks through an end-to-end test.
+
+All helpers accept the dynamically-allocated RPC URLs from the `testWithRpc` fixture ([see 02-lifecycle.md](./02-lifecycle.md)). Spread `...rpc` into calls to pass all three.
+
+## The `AAParamType` contract
+
+All account-factory helpers take a config shaped like this (`packages/permissionless-test/src/types.ts:4`):
+
+```ts
+export type AAParamType<entryPointVersion extends EntryPointVersion> = {
+    entryPoint: { version: entryPointVersion }
+    anvilRpc: string
+    altoRpc: string
+    paymasterRpc: string
+    privateKey?: Hex
+}
+```
+
+- `entryPoint.version` is `"0.6" | "0.7" | "0.8"`. It's a narrow type parameter so callers get a compile error if they try to use an unsupported version for a given account family.
+- `privateKey` is optional; every helper defaults to `generatePrivateKey()` if omitted, producing a fresh signer per invocation.
+
+Test bodies almost always get `rpc` from the fixture and spread it:
+
+```ts
+const account = await getSimpleAccountClient({
+    entryPoint: { version: "0.7" },
+    ...rpc            // anvilRpc + altoRpc + paymasterRpc come from testWithRpc
+})
+```
+
+## Viem base clients
+
+### `getPublicClient(anvilRpc)`
+
+`utils.ts:226`. A viem `PublicClient` against the local Anvil.
+
+```ts
+export const getPublicClient = (anvilRpc: string) => {
+    const transport = http(anvilRpc, {
+        // onFetchRequest / onFetchResponse hooks available for debugging (commented out)
+    })
+    return createPublicClient({
+        chain: foundry,
+        transport,
+        pollingInterval: 100
+    })
+}
+```
+
+- `chain: foundry` → matches `chainId: foundry.id` set on Anvil.
+- `pollingInterval: 100` → aggressive polling; tests wait on receipts often and the block time is effectively instant.
+- Commented-out `onFetchRequest` / `onFetchResponse` hooks are left in place for easy RPC-level debugging — uncomment them to dump every request/response.
+
+### `getAnvilWalletClient({ addressIndex, anvilRpc })`
+
+`utils.ts:99`. A viem `WalletClient` backed by one of Anvil's pre-funded mnemonic accounts.
+
+```ts
+return createWalletClient({
+    account: mnemonicToAccount(
+        "test test test test test test test test test test test junk",
+        { addressIndex }
+    ),
+    chain: foundry,
+    transport: http(anvilRpc)
+})
+```
+
+Use this when a test needs to send a regular EOA transaction (e.g. fund a smart account, deploy a token, manipulate chain state). Pass different `addressIndex` values if one test needs multiple EOAs with distinct nonces.
+
+## ERC-4337 clients
+
+### `getPimlicoClient({ entryPointVersion, altoRpc })`
+
+`utils.ts:199`. Wraps `createPimlicoClient(...)` with the right entry-point address resolved from `entryPointVersion`:
+
+```ts
+const address = (() => {
+    if (entryPointVersion === "0.6") return entryPoint06Address
+    if (entryPointVersion === "0.7") return entryPoint07Address
+    return entryPoint08Address
+})()
+
+return createPimlicoClient({
+    chain: foundry,
+    entryPoint: { address, version: entryPointVersion },
+    transport: http(altoRpc)
+})
+```
+
+Used when tests need direct access to Pimlico bundler RPC methods (`pimlico_getUserOperationGasPrice`, `pimlico_getTokenQuotes`, etc.).
+
+### `getBundlerClient({ altoRpc, anvilRpc, account, paymasterRpc, entryPoint })`
+
+`utils.ts:115`. Builds a full `SmartAccountClient` ready to send user operations.
+
+```ts
+const paymaster = paymasterRpc
+    ? createPimlicoClient({
+          transport: http(paymasterRpc),
+          entryPoint: { address, version: entryPoint.version }
+      })
+    : undefined
+
+const pimlicoBundler = createPimlicoClient({
+    transport: http(altoRpc),
+    entryPoint: { address, version: entryPoint.version }
+})
+
+return createSmartAccountClient({
+    client: getPublicClient(anvilRpc),
+    account,
+    paymaster,
+    bundlerTransport: http(altoRpc),
+    userOperation: {
+        estimateFeesPerGas: async () => {
+            return (await pimlicoBundler.getUserOperationGasPrice()).fast
+        }
+    }
+})
+```
+
+Notable:
+- If `paymasterRpc` is provided, sponsorship happens via the mock paymaster (tests that exercise the paymaster flow).
+- Gas pricing uses `pimlico_getUserOperationGasPrice().fast` instead of eth_gasPrice — matches what Pimlico users do in production.
+
+### `getSmartAccountClient({ altoRpc, anvilRpc, account, paymasterRpc })`
+
+`utils.ts:171`. Similar to `getBundlerClient` but:
+- Uses plain `createPaymasterClient(...)` (not the Pimlico variant) for the paymaster transport.
+- Does **not** override `estimateFeesPerGas` — the SDK uses defaults.
+
+Used in ERC-7579 tests (install/uninstall modules) where the test doesn't care about Pimlico-specific gas pricing.
+
+## Smart-account factory helpers
+
+All return a `SmartAccount` ready to be plugged into `getBundlerClient(...)` as the `account` field.
+
+### `getSimpleAccountClient(conf)` — `utils.ts:243`
+
+```ts
+return toSimpleSmartAccount({
+    client: getPublicClient(anvilRpc),
+    entryPoint: {
+        address: entryPointMapping[entryPoint.version],
+        version: entryPoint.version
+    },
+    owner: privateKeyToAccount(privateKey ?? generatePrivateKey())
+})
+```
+
+- Supports v0.6 / v0.7 / v0.8.
+- EIP-1271: no.
+
+### `get7702SimpleAccountClient(conf)` — `utils.ts:268`
+
+```ts
+return to7702SimpleSmartAccount({
+    client: getPublicClient(anvilRpc),
+    entryPoint: { address: entryPoint08Address, version: "0.8" },
+    owner: privateKeyToAccount(privateKey ?? generatePrivateKey())
+})
+```
+
+- v0.8 only.
+- EIP-7702 compliant.
+
+### `getLightAccountClient({ entryPoint, anvilRpc, version, privateKey })` — `utils.ts:282`
+
+- Versions: `"1.1.0"` (default, v0.6), `"2.0.0"` (v0.7).
+- EntryPoint: depends on version.
+- EIP-1271: yes.
+
+### `getTrustAccountClient(conf)` — `utils.ts:307`
+
+- v0.6 only. EntryPoint hardcoded to v0.6.
+- EIP-1271: yes.
+
+### `getBiconomyClient(conf)` — `utils.ts:324`
+
+- v0.6 only. EntryPoint hardcoded to v0.6.
+- EIP-1271: yes.
+- Signature passed as `owners: [...]` (not `owner`).
+
+### `getNexusClient(conf)` — `utils.ts:340`
+
+- v0.7 only; entryPoint is inferred by `toNexusSmartAccount` itself.
+- Hardcoded `version: "1.0.0"`.
+- EIP-1271: yes. ERC-7579: yes.
+
+### `getKernelEcdsaClient({ entryPoint, anvilRpc, version, privateKey, useMetaFactory, eip7702 })` — `utils.ts:351`
+
+Most flexible helper:
+- Versions: `"0.2.1"`, `"0.2.2"` (default), `"0.2.3"`, `"0.2.4"` (all v0.6); `"0.3.0-beta"`, `"0.3.1"`, `"0.3.2"`, `"0.3.3"` (all v0.7).
+- `useMetaFactory: false` → deploys directly via per-version factory; `useMetaFactory: true` (default) → deploys via the meta-factory `0xd703…42d5`.
+- `eip7702: true` → short-circuits to `to7702KernelSmartAccount(...)` instead. Ignores `version`; always uses Kernel v0.3.3.
+- EIP-1271: yes. ERC-7579: yes (for v0.7 versions).
+
+Throws `Error("Kernel ERC7579 is not supported for V06")` if you ask for a v0.3.x Kernel on EntryPoint v0.6.
+
+### `getSafeClient({ entryPoint, anvilRpc, erc7579, privateKey, owners, onchainIdentifier, version })` — `utils.ts:396`
+
+- Versions: `"1.4.1"` (default) or `"1.5.0"`.
+- `owners`: optional array of viem `Account`s. Defaults to `[privateKeyToAccount(privateKey ?? generatePrivateKey())]`.
+- `erc7579: true` → uses Safe's 7579 module `0x7579EE…0002` + launchpad `0x7579011…00ff`, configures the Rhinestone attester threshold.
+- `onchainIdentifier`: optional partner tag bytes.
+- Hardcoded `saltNonce: 420n`.
+- EIP-1271: yes (except ERC-7579 Safe 1.5.0 — see `getCoreSmartAccounts` flags).
+
+### `getThirdwebClient(conf)` — `utils.ts:444`
+
+- Versions: hardcoded `"1.5.20"`.
+- Supports v0.6 and v0.7 via `entryPoint.version`.
+- EIP-1271: yes.
+
+### `getEtherspotClient(conf)` — `utils.ts:470`
+
+- v0.7 only; entryPoint is hardcoded.
+- **Ignores `privateKey`** — always generates a fresh key.
+- EIP-1271: yes.
+
+## `getCoreSmartAccounts()` — the matrix driver
+
+`utils.ts:485–1091`. Returns an array of **every** account configuration the test suite cares about. Each entry has:
+
+```ts
+{
+    name: string
+    supportsEntryPointV06: boolean
+    supportsEntryPointV07: boolean
+    supportsEntryPointV08: boolean
+    isEip7702Compliant?: boolean
+    isEip1271Compliant: boolean
+    getSmartAccountClient: (conf: AAParamType<EntryPointVersion>) => Promise<SmartAccountClient<...>>
+    getErc7579SmartAccountClient?: (conf) => Promise<SmartAccountClient<...>>
+}
+```
+
+Current entries (names quoted verbatim from source):
+
+| Name                                                | Supports EP    | EIP-7702 | EIP-1271 | ERC-7579 helper |
+| --------------------------------------------------- | -------------- | -------- | -------- | --------------- |
+| Trust                                               | v0.6           | —        | yes      | —               |
+| LightAccount 1.1.0                                  | v0.6           | —        | yes      | —               |
+| LightAccount 2.0.0                                  | v0.7           | —        | yes      | —               |
+| Simple                                              | v0.6, v0.7, v0.8 | —      | no       | —               |
+| Simple + EIP-7702                                   | v0.8           | yes      | no       | —               |
+| Kernel 0.2.1 / 0.2.2 / 0.2.3 / 0.2.4                | v0.6           | —        | yes      | —               |
+| Kernel 7579 0.3.0-beta (non meta factory deployment) | v0.7          | —        | yes      | yes             |
+| Kernel 7579 0.3.0-beta                              | v0.7           | —        | yes      | yes             |
+| Kernel 7579 0.3.1 (non meta factory deployment)     | v0.7           | —        | yes      | yes             |
+| Kernel 7579 0.3.1 / 0.3.2 / 0.3.3                   | v0.7           | —        | yes      | yes             |
+| Kernel 0.3.3 + EIP-7702                             | v0.7           | yes      | yes      | —               |
+| Biconomy                                            | v0.6           | —        | yes      | —               |
+| Nexus                                               | v0.7           | —        | yes      | yes             |
+| Safe                                                | v0.6, v0.7     | —        | yes      | —               |
+| Safe 1.5.0                                          | v0.7           | —        | yes      | —               |
+| Safe (with onchain identifier)                      | v0.6, v0.7     | —        | yes      | —               |
+| Safe 1.5.0 (with onchain identifier)                | v0.7           | —        | yes      | —               |
+| Safe multiple owners                                | v0.6, v0.7     | —        | yes      | —               |
+| Safe 1.5.0 multiple owners                          | v0.7           | —        | yes      | —               |
+| Safe 7579                                           | v0.7           | —        | yes      | yes             |
+| Safe 1.5.0 7579                                     | v0.7           | —        | **no**   | yes             |
+| Safe 7579 Multiple Owners                           | v0.7           | —        | yes      | yes             |
+| Safe 1.5.0 7579 Multiple Owners                     | v0.7           | —        | **no**   | yes             |
+| Etherspot                                           | v0.7           | —        | yes      | —               |
+| Thirdweb                                            | v0.6, v0.7     | —        | yes      | —               |
+
+Tests use this with `describe.each(getCoreSmartAccounts())` to generate a Cartesian product of (account × entry-point version). Each inner `testWithRpc.skipIf(!supportsEntryPointVXX)(...)` disables the combos that don't apply.
+
+## Readiness helpers
+
+- `ensureBundlerIsReady({ altoRpc, anvilRpc })` — `utils.ts:61`. Polls `bundlerClient.getChainId()` until Alto responds. Mostly redundant (the fixture already waits).
+- `ensurePaymasterIsReady()` — `utils.ts:83`. Polls `GET /ping` on the **hard-coded** `http://localhost:3000` (the `PAYMASTER_RPC` constant at `utils.ts:59`). Works only if a paymaster happens to be on port 3000.
+
+Tests normally rely on the fixture's setup promise and skip these helpers.
+
+## End-to-end walkthrough
+
+A real test annotated line by line. `packages/permissionless/actions/smartAccount/sendTransaction.test.ts:1`:
+
+```ts
+import { zeroAddress } from "viem"
+import { describe, expect } from "vitest"
+// ⬇ the custom test fn that provisions {anvilRpc, altoRpc, paymasterRpc}
+import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
+// ⬇ factory list + helpers
+import {
+    getCoreSmartAccounts,
+    getPublicClient
+} from "../../../permissionless-test/src/utils"
+import { sendTransaction } from "./sendTransaction"
+
+// ⬇ one describe block per account configuration.
+//   $name is interpolated from `name` on each entry (vitest convention).
+describe.each(getCoreSmartAccounts())(
+    "sendTransaction $name",
+    ({
+        getSmartAccountClient,
+        supportsEntryPointV06,
+        supportsEntryPointV07,
+        supportsEntryPointV08,
+        isEip7702Compliant
+    }) => {
+        // ⬇ runs only if this account supports EntryPoint v0.6.
+        //   Whole fixture (anvil/alto/paymaster setup) is skipped otherwise.
+        testWithRpc.skipIf(!supportsEntryPointV06)(
+            "sendTransaction_v06",
+            async ({ rpc }) => {
+                const { anvilRpc } = rpc
+
+                // ⬇ Build a SmartAccountClient wired to:
+                //   - local anvil   (public/wallet)
+                //   - local alto    (bundler, gas price)
+                //   - (no paymaster for this test — conf doesn't spread paymasterRpc)
+                const smartClient = await getSmartAccountClient({
+                    entryPoint: { version: "0.6" },
+                    ...rpc
+                })
+
+                // ⬇ Sends a real user op: estimate → sign → eth_sendUserOperation to alto
+                //   → alto bundles → submits via anvil → txn mined → receipt returned
+                const transactionHash = await sendTransaction(smartClient, {
+                    to: zeroAddress,
+                    data: "0x",
+                    value: 0n
+                })
+
+                expect(transactionHash).toBeTruthy()
+
+                // ⬇ Independent public client to verify on-chain state
+                const publicClient = getPublicClient(anvilRpc)
+                const receipt = await publicClient.getTransactionReceipt({ hash: transactionHash })
+
+                expect(receipt).toBeTruthy()
+                expect(receipt.status).toBe("success")
+                // ... rest of the test: send a second txn after the account is deployed
+            }
+        )
+        // ... corresponding _v07 / _v08 blocks, gated on their own supports flags
+    }
+)
+```
+
+When Vitest runs this file:
+
+1. It discovers N `describe` blocks (one per `getCoreSmartAccounts()` entry).
+2. Each block has up to 3 `testWithRpc` calls (v0.6 / v0.7 / v0.8), some of which are skipped.
+3. For every non-skipped test: fixture spins up anvil + contracts + alto + paymaster, the body runs, everything stops.
+4. Because `sequence.concurrent: false`, tests within this file run one at a time.
+
+Typical wall-clock for this one file: on the order of tens of seconds to a few minutes depending on how many accounts × versions are live.
+
+## Wiring a new account helper
+
+To add support for a new smart-account type:
+
+1. **Deploy its contracts** — see [04-contracts.md § Adding a new contract](./04-contracts.md#adding-a-new-contract).
+
+2. **Add a `get<Name>Client(conf: AAParamType<...>)`** in `utils.ts`. Match the pattern of existing helpers:
+
+   ```ts
+   export const getFooClient = async <V extends "0.7">({
+       anvilRpc,
+       privateKey
+   }: AAParamType<V>) => {
+       return toFooSmartAccount({
+           client: getPublicClient(anvilRpc),
+           entryPoint: { address: entryPoint07Address, version: "0.7" },
+           owner: privateKeyToAccount(privateKey ?? generatePrivateKey())
+       })
+   }
+   ```
+
+3. **Add a `getCoreSmartAccounts()` entry** if the new type should participate in matrix tests. Set `supportsEntryPointV0X` flags to match reality and provide `getSmartAccountClient` (and `getErc7579SmartAccountClient` if it's an ERC-7579 account).
+
+4. **Run one matrix test** (`bun run test -t "sendTransaction Foo"`) to confirm everything wires up.
+
+→ Next: [06-ci-and-running.md](./06-ci-and-running.md)

--- a/docs/testing/06-ci-and-running.md
+++ b/docs/testing/06-ci-and-running.md
@@ -1,0 +1,181 @@
+# 06 — CI & running tests
+
+This document covers the three `test` scripts, CI configuration, environment variables, fork mode, running subsets of tests, and troubleshooting.
+
+## The three test scripts
+
+From `package.json:92–94`:
+
+```json
+"test":               "vitest dev -c ./packages/permissionless/vitest.config.ts",
+"test:ci-no-coverage": "CI=true && vitest -c ./packages/permissionless/vitest.config.ts --pool=forks",
+"test:ci":             "CI=true && vitest -c ./packages/permissionless/vitest.config.ts --coverage --pool=forks"
+```
+
+| Script                   | When to use           | Mode                | Coverage                    | Pool            |
+| ------------------------ | --------------------- | ------------------- | --------------------------- | --------------- |
+| `bun run test`           | Local dev             | `vitest dev` (watch) | text + json + html reporters | default (threads) |
+| `bun run test:ci-no-coverage` | Quick full CI-style run locally | one-shot | none                       | `--pool=forks`  |
+| `bun run test:ci`        | What CI runs          | one-shot            | lcov only                   | `--pool=forks`  |
+
+Why `--pool=forks`? The default Vitest pool uses worker **threads**; `forks` uses worker **processes**. Because each test spawns multiple child processes (Anvil, Alto, Fastify) and relies on `prool` signal handling, process-pool isolation is safer and more reliable, at the cost of slightly higher memory usage.
+
+The `CI=true &&` prefix in the CI scripts sets the environment variable so `vitest.config.ts:10` picks the lcov-only reporter:
+
+```ts
+reporter: process.env.CI ? ["lcov"] : ["text", "json", "html"]
+```
+
+## CI workflow
+
+The live CI path is **`.github/workflows/on-pull-request.yml`**, which runs on every PR event:
+
+```yaml
+jobs:
+  verify:
+    uses: ./.github/workflows/verify.yml   # lint + build
+
+  docker-e2e:
+    name: E2E-Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-dependencies
+      - uses: actions/setup-node@v4
+        with: { node-version: "v22.2.0" }
+      - run: bun run build
+      - run: echo "VITE_FORK_RPC_URL=${{ secrets.VITE_FORK_RPC_URL }}" > .env.test
+      - run: bun run test:ci
+      - uses: codecov/codecov-action@v3
+```
+
+Key points:
+
+- **Node 22.2.0** is used in CI; local dev with a different Node should match this for parity.
+- `.env.test` is **generated in-workflow** with `VITE_FORK_RPC_URL` from a GitHub secret. When the secret is unset, the value is empty and `setupContracts` runs normally. When set, Anvil forks that URL and `setupContracts` is skipped ([see fork mode](#fork-mode)).
+- Coverage is uploaded to Codecov via `codecov-action@v3`.
+- Timeout: 60 minutes.
+
+### The disabled sharded test job
+
+`.github/workflows/verify.yml:77–114` defines a matrix-sharded `test` job (3 shards × 2 transport modes × `nick-fields/retry@v2` with 3 attempts). It's **disabled** by `if: false` at `verify.yml:78` and doesn't currently run. It references `VITE_ANVIL_BLOCK_NUMBER`, `VITE_ANVIL_BLOCK_TIME`, `VITE_ANVIL_FORK_URL`, `VITE_BATCH_MULTICALL`, and `VITE_NETWORK_TRANSPORT_MODE` env vars — but because the job is gated off, these are not live right now. If re-enabled, see the workflow file for the exact env-var names.
+
+## Environment variables
+
+Loaded by Vitest via `loadEnv("test", process.cwd())` (`vitest.config.ts:29`), which reads, in order: `.env.test.local`, `.env.test`, `.env.local`, `.env` (typical Vite precedence). Only variables starting with `VITE_` are exposed to test code via `import.meta.env`.
+
+| Variable                 | Read where                                   | Effect                                                                                   |
+| ------------------------ | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `VITE_FORK_RPC_URL`      | `testWithRpc.ts:25`                          | If set, Anvil boots as a fork of this URL and `setupContracts` is **skipped**.           |
+| `CI`                     | `vitest.config.ts:10`                        | Switches coverage reporter to `lcov` only.                                               |
+
+Other `VITE_*` vars (`VITE_ANVIL_BLOCK_NUMBER`, `VITE_ANVIL_BLOCK_TIME`, `VITE_NETWORK_TRANSPORT_MODE`, `VITE_BATCH_MULTICALL`, `VITE_ANVIL_FORK_URL`) appear in `verify.yml` but are only consumed by the disabled sharded job. They have no effect in the active `testWithRpc` fixture.
+
+## Fork mode
+
+Set `VITE_FORK_RPC_URL` to any EVM JSON-RPC endpoint (e.g. a mainnet or testnet archive node) to run tests against a forked chain instead of a freshly-deployed one.
+
+Two ways to enable:
+
+```bash
+# option A: per-invocation
+VITE_FORK_RPC_URL=https://eth.llamarpc.com bun run test
+
+# option B: persistent
+echo 'VITE_FORK_RPC_URL=https://eth.llamarpc.com' > .env.test
+bun run test
+```
+
+Behaviour changes:
+
+- Anvil is started with `forkUrl` set (`testWithRpc.ts:29`).
+- `setupContracts(anvilRpc)` is **not called** (`testWithRpc.ts:70`). The fork is expected to already contain EntryPoints + factories at their canonical deterministic addresses.
+- Alto and the mock paymaster still start normally.
+
+Caveats:
+
+- The fork is recreated per-test, so every test issues a fresh set of forked reads. Use a reliable/high-rate archive node or expect throttling.
+- If the forked chain's `chainId ≠ foundry.id (31337)`, `eth_chainId` will differ and viem clients configured with `chain: foundry` may misbehave. The test fixture explicitly sets `chainId: foundry.id` on the Anvil instance to paper over this for most cases.
+- Smart account addresses computed counterfactually from factory addresses only match reality if the factories on the forked chain match the deterministic-deployer addresses used locally.
+
+## Running subsets
+
+Because `bun run test` runs `vitest dev` (watch mode), it exposes Vitest's interactive filters. You can also pass filters on the CLI:
+
+```bash
+# single test file
+bun run test packages/permissionless/actions/smartAccount/sendTransaction.test.ts
+
+# by test-name substring
+bun run test -t "sendTransaction Safe"
+
+# one matrix entry × one version
+bun run test -t "sendTransaction Safe 1.5.0" -t "v07"
+
+# non-watch single run
+bun run test:ci-no-coverage packages/permissionless/utils/decodeNonce.test.ts
+```
+
+Vitest's interactive keyboard controls in watch mode (`p` for file filter, `t` for test-name filter, `q` to quit, etc.) also work.
+
+## Troubleshooting
+
+### "Server listening at" never appears → `hookTimeout` error
+
+Alto is failing to start silently. The `prool` wrapper listens for the literal string `"Server listening at"` on Alto's stdout (`mock-aa-infra/alto/instance.ts:278`) and does not inspect stderr. If Alto crashes on boot, the hook hangs until the 45s `hookTimeout` fires.
+
+**Fix:**
+
+1. Uncomment the stderr hooks in `testWithRpc.ts:55–60` temporarily:
+   ```ts
+   altoInstance.on("stderr", (data) => console.error(data.toString()))
+   altoInstance.on("stdout", (data) => console.log(data.toString()))
+   ```
+2. Re-run the failing test to see Alto's error output.
+3. Common causes: a contract in `setupContracts` didn't deploy (check `verifyDeployed`'s exit message), port conflict, `@pimlico/alto` version mismatch after a dependency update.
+
+### A contract "NOT DEPLOYED!!!" message
+
+`setupContracts` calls `verifyDeployed` at the end (`mock-aa-infra/alto/index.ts:92`) and `process.exit(1)` for any address with no bytecode. The message identifies the missing address — map it back to the manifest at `mock-aa-infra/alto/index.ts:711–782` to find which contract is missing.
+
+Common causes:
+- A new `*_CREATECALL` constant was added but not sent as a transaction in `setupContracts`.
+- The creation-call bytes were regenerated with a different salt, changing the deterministic address.
+- A dependent contract's batch is missing from `verifyDeployed`'s manifest.
+
+### Tests hang on teardown
+
+If `.stop()` on one of the instances hangs, the per-test hook times out. Usually caused by a zombie child process from a prior run. Find and kill it:
+
+```bash
+pgrep -f "alto"   # alto Node process
+pgrep -f "anvil"  # anvil
+pgrep -f "node.*mock-paymaster"  # mock paymaster
+```
+
+Then `kill -9 <pid>` and retry.
+
+### `EADDRINUSE: address already in use`
+
+`get-port` normally prevents this, but if a background process (e.g. a local dev server) grabs the same port between the `getPort()` call and the service actually listening, you'll see this. Re-run; the probability of collision on the retry is negligible.
+
+### Fork mode: tests that used to pass now fail
+
+Most likely `setupContracts` assumes a clean slate (fresh nonces on Anvil's account 0, etc.), and the forked chain has a different state for that account. Check whether the failing test:
+
+- Uses `getAnvilWalletClient({ addressIndex: 0 })` and expects a specific starting nonce.
+- Relies on a factory's *counterfactual* address matching the one `toXxxSmartAccount` computes — the factory must exist on the forked chain.
+
+### Coverage report is missing
+
+If `bun run test:ci` completes but Codecov upload fails or no local `coverage/` appears:
+
+- Running `bun run test` (not `test:ci`) with `process.env.CI` unset produces HTML at `coverage/index.html`.
+- `bun run test:ci` only produces `coverage/lcov.info` by design (see reporter switch in `vitest.config.ts:10`).
+
+## Related reading
+
+- [01-architecture.md](./01-architecture.md) — full command chain and vitest config details.
+- [02-lifecycle.md](./02-lifecycle.md) — the `testWithRpc` fixture internals.
+- [04-contracts.md](./04-contracts.md) — why fork mode can skip `setupContracts`.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,78 @@
+# Test Infrastructure
+
+This directory documents how the `permissionless.js` test suite works end-to-end — from `bun run test` down to the individual user operation flying through a local bundler.
+
+## The short version
+
+Every test in this repository runs against **its own dedicated ERC-4337 stack**:
+
+1. A fresh **Anvil** node (L1 EVM).
+2. A fresh **Alto** bundler (`@pimlico/alto`) pointed at that Anvil.
+3. A fresh **mock paymaster** (Fastify server) pointed at both Anvil and Alto.
+
+These three processes are spawned on dynamically-allocated ports, all core smart-account contracts (EntryPoints v0.6/v0.7/v0.8, SimpleAccount, Safe, Kernel, LightAccount, Biconomy, Trust, Nexus, Etherspot, Thirdweb, ERC-7579 modules, …) are deployed via a deterministic deployer, and then the test body receives `{ anvilRpc, altoRpc, paymasterRpc }` to wire up viem clients. After the test returns, all three processes are stopped and their ports released.
+
+This guarantees complete state isolation: no test can see state produced by another, and tests within the same file run serially but files run in parallel.
+
+## Per-test lifecycle
+
+```
+┌─────────────────────────── one test ──────────────────────────────┐
+│                                                                   │
+│  1. allocate 3 ports via get-port (alto, paymaster, anvil)        │
+│  2. start anvil on anvilPort (chainId=foundry, hardfork=Prague)   │
+│  3. setupContracts(anvilRpc)                                      │
+│       └─ ~80 txns to the deterministic deployer +                 │
+│          a few setCode / impersonateAccount calls                 │
+│  4. start alto on altoPort (entrypoints: [0.6, 0.7, 0.8])         │
+│  5. start mock-paymaster on paymasterPort                         │
+│                                                                   │
+│  6. ── test body runs ──                                          │
+│     receives: { anvilRpc, altoRpc, paymasterRpc }                 │
+│     builds: public client, wallet client, bundler client,         │
+│             pimlico client, smart account(s), etc.                │
+│                                                                   │
+│  7. stop all 3 instances (Promise.all)                            │
+│  8. release ports                                                 │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+## What to read
+
+Read these in order if you're new. Each document is self-contained; cross-links point to the relevant file.
+
+| #   | Doc                                                   | What's in it                                                                          |
+| --- | ----------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 01  | [01-architecture.md](./01-architecture.md)            | `bun run test` command chain, `vitest.config.ts`, file layout, test discovery.        |
+| 02  | [02-lifecycle.md](./02-lifecycle.md)                  | The `testWithRpc` fixture: ports, setup, teardown, state isolation guarantees.        |
+| 03  | [03-infrastructure.md](./03-infrastructure.md)        | Anvil, Alto, and the mock paymaster — how each process is spawned and configured.     |
+| 04  | [04-contracts.md](./04-contracts.md)                  | `setupContracts`, the deterministic deployer, the full contract catalog, how to add a new one. |
+| 05  | [05-clients-accounts.md](./05-clients-accounts.md)    | Every viem/Pimlico/smart-account helper in `packages/permissionless-test/src/utils.ts`. |
+| 06  | [06-ci-and-running.md](./06-ci-and-running.md)        | Local vs CI scripts, env vars, fork mode, running single tests, troubleshooting.      |
+
+## "If you want to…" cheat sheet
+
+| Task                                         | Go to                                                                        |
+| -------------------------------------------- | ---------------------------------------------------------------------------- |
+| Understand what `bun run test` actually does | [01-architecture.md](./01-architecture.md)                                   |
+| Write a new test                             | [05-clients-accounts.md § End-to-end walkthrough](./05-clients-accounts.md#end-to-end-walkthrough) |
+| Support a new smart-account type             | [04-contracts.md § Adding a new contract](./04-contracts.md#adding-a-new-contract) + [05-clients-accounts.md § Wiring a new account helper](./05-clients-accounts.md#wiring-a-new-account-helper) |
+| Run tests against a forked network           | [06-ci-and-running.md § Fork mode](./06-ci-and-running.md#fork-mode)          |
+| Run a single test / test file                | [06-ci-and-running.md § Running subsets](./06-ci-and-running.md#running-subsets) |
+| Debug a hanging test                         | [06-ci-and-running.md § Troubleshooting](./06-ci-and-running.md#troubleshooting) |
+
+## Key files
+
+Everything test-related lives in three packages:
+
+- `packages/permissionless/vitest.config.ts` — the Vitest config that `bun run test` points at.
+- `packages/permissionless-test/` — shared fixtures, client helpers, and the mock bundler infra. **Not published; test-only.**
+  - `src/testWithRpc.ts` — the `test.extend(...)` fixture that spins up the stack.
+  - `src/utils.ts` — every `get*Client`/`get*AccountClient` helper tests reach for.
+  - `src/types.ts` — `AAParamType`.
+  - `mock-aa-infra/alto/index.ts` — `setupContracts()` that deploys everything.
+  - `mock-aa-infra/alto/instance.ts` — the `alto` process wrapper built on `prool`.
+  - `mock-aa-infra/alto/constants/` — pre-computed `*_CREATECALL` bytecode used by `setupContracts`.
+- `packages/mock-paymaster/` — the Fastify mock paymaster server (also a `prool` instance).
+
+Tests themselves are colocated with source code as `*.test.ts` files under `packages/permissionless/`.

--- a/packages/permissionless/package.json
+++ b/packages/permissionless/package.json
@@ -11,13 +11,7 @@
     "type": "module",
     "sideEffects": false,
     "description": "A utility library for working with ERC-4337",
-    "keywords": [
-        "ethereum",
-        "erc-4337",
-        "eip-4337",
-        "paymaster",
-        "bundler"
-    ],
+    "keywords": ["ethereum", "erc-4337", "eip-4337", "paymaster", "bundler"],
     "license": "MIT",
     "exports": {
         ".": {


### PR DESCRIPTION
Add docs/testing/ covering how `bun run test` works: the vitest config, the per-test testWithRpc fixture, the Anvil/Alto/mock-paymaster process trio, contract injection via the deterministic deployer, every viem and smart-account helper in permissionless-test, and CI/fork-mode behaviour.