### PR TITLE
perf(test): share test infrastructure per worker and use unique keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ temp.ts
 .env.production.local
 .envrc
 .vscode
+.claude

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,7 +2,7 @@
     {
         "name": "permissionless (esm)",
         "path": "./packages/permissionless/_esm/index.js",
-        "limit": "60 kB",
+        "limit": "250 kB",
         "import": "*"
     },
     {

--- a/bun.lock
+++ b/bun.lock
@@ -2,9 +2,6 @@
   "lockfileVersion": 1,
   "workspaces": {
     "": {
-      "dependencies": {
-        "@typescript/native-preview": "^7.0.0-dev.20260103.1",
-      },
       "devDependencies": {
         "@biomejs/biome": "^1.0.0",
         "@changesets/changelog-git": "^0.1.14",
@@ -18,6 +15,7 @@
         "@tanstack/react-query": "5.45.1",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.0",
+        "@typescript/native-preview": "^7.0.0-dev.20260103.1",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitest/coverage-v8": "^2.1.5",
         "@wagmi/cli": "latest",
@@ -26,7 +24,7 @@
         "buffer": "^6.0.3",
         "bun-types": "^1.0.7",
         "get-port": "^7.0.0",
-        "ox": "0.8.0",
+        "ox": "0.11.3",
         "prool": "^0.0.25",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -36,7 +34,7 @@
         "tsc-alias": "^1.8.8",
         "tslib": "^2.6.2",
         "typescript": "^5.2.2",
-        "viem": "2.28.1",
+        "viem": "2.44.4",
         "vite": "^5.4.10",
         "vitest": "^2.1.5",
         "wagmi": "^2.15.1",
@@ -44,7 +42,7 @@
     },
     "packages/mock-paymaster": {
       "name": "@pimlico/mock-paymaster",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@fastify/cors": "^8.5.0",
         "fastify": "^4.28.1",
@@ -53,15 +51,15 @@
       },
       "peerDependencies": {
         "prool": "^0.0.25",
-        "viem": "^2.28.1",
+        "viem": "^2.44.4",
       },
     },
     "packages/permissionless": {
       "name": "permissionless",
-      "version": "0.3.2",
+      "version": "0.3.5",
       "peerDependencies": {
-        "ox": "^0.8.0",
-        "viem": "^2.28.1",
+        "ox": "^0.11.3",
+        "viem": "^2.44.4",
       },
       "optionalPeers": [
         "ox",
@@ -326,7 +324,7 @@
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
-    "@noble/curves": ["@noble/curves@1.9.2", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g=="],
+    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -1088,7 +1086,7 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
+    "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
 
     "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
 
@@ -1242,7 +1240,7 @@
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
-    "ox": ["ox@0.8.0", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.8", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-jYfJVFabaDTqeGAOmIfGrtqOTP3Qzqk99osROlFzHCpeDkS2pH6oz0xFfC4lAo83QKTFDGBseTgnqSfNXtOLNg=="],
+    "ox": ["ox@0.11.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw=="],
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 
@@ -1552,7 +1550,7 @@
 
     "valtio": ["valtio@1.13.2", "", { "dependencies": { "derive-valtio": "0.1.0", "proxy-compare": "2.6.0", "use-sync-external-store": "1.2.0" }, "peerDependencies": { "@types/react": ">=16.8", "react": ">=16.8" }, "optionalPeers": ["@types/react", "react"] }, "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A=="],
 
-    "viem": ["viem@2.28.1", "", { "dependencies": { "@noble/curves": "1.8.2", "@noble/hashes": "1.7.2", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.9", "ws": "8.18.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-7eqGfxAPlMW9u9aE3SMEFPzNYqqU7uFLKUQyd/GwccyW4OAdq7VqJkPIpdULUePN9m3XmfBunA9mswYFp9sUuQ=="],
+    "viem": ["viem@2.44.4", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.11.3", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-sJDLVl2EsS5Fo7GSWZME5CXEV7QRYkUJPeBw7ac+4XI3D4ydvMw/gjulTsT5pgqcpu70BploFnOAC6DLpan1Yg=="],
 
     "vite": ["vite@5.4.14", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA=="],
 
@@ -1584,7 +1582,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
+    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
 
@@ -1796,13 +1794,23 @@
 
     "@reown/appkit/@walletconnect/universal-provider": ["@walletconnect/universal-provider@2.19.2", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/jsonrpc-http-connection": "1.0.8", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/sign-client": "2.19.2", "@walletconnect/types": "2.19.2", "@walletconnect/utils": "2.19.2", "es-toolkit": "1.33.0", "events": "3.3.0" } }, "sha512-LkKg+EjcSUpPUhhvRANgkjPL38wJPIWumAYD8OK/g4OFuJ4W3lS/XTCKthABQfFqmiNbNbVllmywiyE44KdpQg=="],
 
+    "@reown/appkit/viem": ["viem@2.28.1", "", { "dependencies": { "@noble/curves": "1.8.2", "@noble/hashes": "1.7.2", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.9", "ws": "8.18.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-7eqGfxAPlMW9u9aE3SMEFPzNYqqU7uFLKUQyd/GwccyW4OAdq7VqJkPIpdULUePN9m3XmfBunA9mswYFp9sUuQ=="],
+
+    "@reown/appkit-common/viem": ["viem@2.28.1", "", { "dependencies": { "@noble/curves": "1.8.2", "@noble/hashes": "1.7.2", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.9", "ws": "8.18.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-7eqGfxAPlMW9u9aE3SMEFPzNYqqU7uFLKUQyd/GwccyW4OAdq7VqJkPIpdULUePN9m3XmfBunA9mswYFp9sUuQ=="],
+
     "@reown/appkit-controllers/@walletconnect/universal-provider": ["@walletconnect/universal-provider@2.19.2", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/jsonrpc-http-connection": "1.0.8", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/sign-client": "2.19.2", "@walletconnect/types": "2.19.2", "@walletconnect/utils": "2.19.2", "es-toolkit": "1.33.0", "events": "3.3.0" } }, "sha512-LkKg+EjcSUpPUhhvRANgkjPL38wJPIWumAYD8OK/g4OFuJ4W3lS/XTCKthABQfFqmiNbNbVllmywiyE44KdpQg=="],
 
+    "@reown/appkit-controllers/viem": ["viem@2.28.1", "", { "dependencies": { "@noble/curves": "1.8.2", "@noble/hashes": "1.7.2", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.9", "ws": "8.18.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-7eqGfxAPlMW9u9aE3SMEFPzNYqqU7uFLKUQyd/GwccyW4OAdq7VqJkPIpdULUePN9m3XmfBunA9mswYFp9sUuQ=="],
+
     "@reown/appkit-utils/@walletconnect/universal-provider": ["@walletconnect/universal-provider@2.19.2", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/jsonrpc-http-connection": "1.0.8", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/sign-client": "2.19.2", "@walletconnect/types": "2.19.2", "@walletconnect/utils": "2.19.2", "es-toolkit": "1.33.0", "events": "3.3.0" } }, "sha512-LkKg+EjcSUpPUhhvRANgkjPL38wJPIWumAYD8OK/g4OFuJ4W3lS/XTCKthABQfFqmiNbNbVllmywiyE44KdpQg=="],
+
+    "@reown/appkit-utils/viem": ["viem@2.28.1", "", { "dependencies": { "@noble/curves": "1.8.2", "@noble/hashes": "1.7.2", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.9", "ws": "8.18.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-7eqGfxAPlMW9u9aE3SMEFPzNYqqU7uFLKUQyd/GwccyW4OAdq7VqJkPIpdULUePN9m3XmfBunA9mswYFp9sUuQ=="],
 
     "@reown/appkit-wallet/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
 
     "@safe-global/safe-apps-sdk/viem": ["viem@2.23.2", "", { "dependencies": { "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.7", "ws": "8.18.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA=="],
+
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.2", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g=="],
 
     "@sentry/node/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.57.2", "", { "dependencies": { "@opentelemetry/api-logs": "0.57.2", "@types/shimmer": "^1.2.0", "import-in-the-middle": "^1.8.1", "require-in-the-middle": "^7.1.1", "semver": "^7.5.2", "shimmer": "^1.2.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg=="],
 
@@ -1916,7 +1924,7 @@
 
     "opentelemetry-instrumentation-fetch-node/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.46.0", "", { "dependencies": { "@types/shimmer": "^1.0.2", "import-in-the-middle": "1.7.1", "require-in-the-middle": "^7.1.1", "semver": "^7.5.2", "shimmer": "^1.2.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw=="],
 
-    "ox/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+    "ox/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.0.2", "", {}, "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA=="],
 
@@ -1938,17 +1946,7 @@
 
     "valtio/use-sync-external-store": ["use-sync-external-store@1.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="],
 
-    "viem/@noble/curves": ["@noble/curves@1.8.2", "", { "dependencies": { "@noble/hashes": "1.7.2" } }, "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g=="],
-
-    "viem/@noble/hashes": ["@noble/hashes@1.7.2", "", {}, "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ=="],
-
-    "viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
-
-    "viem/@scure/bip39": ["@scure/bip39@1.5.4", "", { "dependencies": { "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.4" } }, "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA=="],
-
-    "viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
-
-    "viem/ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
+    "viem/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
@@ -2076,9 +2074,9 @@
 
     "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.25.1", "", {}, "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="],
 
-    "@pimlico/alto/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+    "@pimlico/alto/viem/@noble/curves": ["@noble/curves@1.9.2", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g=="],
 
-    "@pimlico/alto/viem/isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
+    "@pimlico/alto/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
 
     "@pimlico/alto/viem/ox": ["ox@0.8.1", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.8", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A=="],
 
@@ -2092,11 +2090,43 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@1.13.1", "", { "dependencies": { "acorn": "^8.14.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^1.2.2", "module-details-from-path": "^1.0.3" } }, "sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA=="],
 
+    "@reown/appkit-common/viem/@noble/curves": ["@noble/curves@1.8.2", "", { "dependencies": { "@noble/hashes": "1.7.2" } }, "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g=="],
+
+    "@reown/appkit-common/viem/@noble/hashes": ["@noble/hashes@1.7.2", "", {}, "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ=="],
+
+    "@reown/appkit-common/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
+
+    "@reown/appkit-common/viem/@scure/bip39": ["@scure/bip39@1.5.4", "", { "dependencies": { "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.4" } }, "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA=="],
+
+    "@reown/appkit-common/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+
+    "@reown/appkit-common/viem/isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
+
+    "@reown/appkit-common/viem/ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
+
+    "@reown/appkit-common/viem/ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
+
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/sign-client": ["@walletconnect/sign-client@2.19.2", "", { "dependencies": { "@walletconnect/core": "2.19.2", "@walletconnect/events": "1.0.1", "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/logger": "2.1.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.19.2", "@walletconnect/utils": "2.19.2", "events": "3.3.0" } }, "sha512-a/K5PRIFPCjfHq5xx3WYKHAAF8Ft2I1LtxloyibqiQOoUtNLfKgFB1r8sdMvXM7/PADNPe4iAw4uSE6PrARrfg=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/types": ["@walletconnect/types@2.19.2", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "events": "3.3.0" } }, "sha512-/LZWhkVCUN+fcTgQUxArxhn2R8DF+LSd/6Wh9FnpjeK/Sdupx1EPS8okWG6WPAqq2f404PRoNAfQytQ82Xdl3g=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.19.2", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.19.2", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-VU5CcUF4sZDg8a2/ov29OJzT3KfLuZqJUM0GemW30dlipI5fkpb0VPenZK7TcdLPXc1LN+Q+7eyTqHRoAu/BIA=="],
+
+    "@reown/appkit-controllers/viem/@noble/curves": ["@noble/curves@1.8.2", "", { "dependencies": { "@noble/hashes": "1.7.2" } }, "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g=="],
+
+    "@reown/appkit-controllers/viem/@noble/hashes": ["@noble/hashes@1.7.2", "", {}, "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ=="],
+
+    "@reown/appkit-controllers/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
+
+    "@reown/appkit-controllers/viem/@scure/bip39": ["@scure/bip39@1.5.4", "", { "dependencies": { "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.4" } }, "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA=="],
+
+    "@reown/appkit-controllers/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+
+    "@reown/appkit-controllers/viem/isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
+
+    "@reown/appkit-controllers/viem/ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
+
+    "@reown/appkit-controllers/viem/ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/sign-client": ["@walletconnect/sign-client@2.19.2", "", { "dependencies": { "@walletconnect/core": "2.19.2", "@walletconnect/events": "1.0.1", "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/logger": "2.1.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.19.2", "@walletconnect/utils": "2.19.2", "events": "3.3.0" } }, "sha512-a/K5PRIFPCjfHq5xx3WYKHAAF8Ft2I1LtxloyibqiQOoUtNLfKgFB1r8sdMvXM7/PADNPe4iAw4uSE6PrARrfg=="],
 
@@ -2104,9 +2134,41 @@
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.19.2", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.19.2", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-VU5CcUF4sZDg8a2/ov29OJzT3KfLuZqJUM0GemW30dlipI5fkpb0VPenZK7TcdLPXc1LN+Q+7eyTqHRoAu/BIA=="],
 
+    "@reown/appkit-utils/viem/@noble/curves": ["@noble/curves@1.8.2", "", { "dependencies": { "@noble/hashes": "1.7.2" } }, "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g=="],
+
+    "@reown/appkit-utils/viem/@noble/hashes": ["@noble/hashes@1.7.2", "", {}, "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ=="],
+
+    "@reown/appkit-utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
+
+    "@reown/appkit-utils/viem/@scure/bip39": ["@scure/bip39@1.5.4", "", { "dependencies": { "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.4" } }, "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA=="],
+
+    "@reown/appkit-utils/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+
+    "@reown/appkit-utils/viem/isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
+
+    "@reown/appkit-utils/viem/ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
+
+    "@reown/appkit-utils/viem/ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
+
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/sign-client": ["@walletconnect/sign-client@2.19.2", "", { "dependencies": { "@walletconnect/core": "2.19.2", "@walletconnect/events": "1.0.1", "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/logger": "2.1.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.19.2", "@walletconnect/utils": "2.19.2", "events": "3.3.0" } }, "sha512-a/K5PRIFPCjfHq5xx3WYKHAAF8Ft2I1LtxloyibqiQOoUtNLfKgFB1r8sdMvXM7/PADNPe4iAw4uSE6PrARrfg=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.19.2", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.19.2", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-VU5CcUF4sZDg8a2/ov29OJzT3KfLuZqJUM0GemW30dlipI5fkpb0VPenZK7TcdLPXc1LN+Q+7eyTqHRoAu/BIA=="],
+
+    "@reown/appkit/viem/@noble/curves": ["@noble/curves@1.8.2", "", { "dependencies": { "@noble/hashes": "1.7.2" } }, "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g=="],
+
+    "@reown/appkit/viem/@noble/hashes": ["@noble/hashes@1.7.2", "", {}, "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ=="],
+
+    "@reown/appkit/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
+
+    "@reown/appkit/viem/@scure/bip39": ["@scure/bip39@1.5.4", "", { "dependencies": { "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.4" } }, "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA=="],
+
+    "@reown/appkit/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+
+    "@reown/appkit/viem/isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
+
+    "@reown/appkit/viem/ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
+
+    "@reown/appkit/viem/ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
 
     "@safe-global/safe-apps-sdk/viem/@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
 
@@ -2117,6 +2179,8 @@
     "@safe-global/safe-apps-sdk/viem/@scure/bip39": ["@scure/bip39@1.5.4", "", { "dependencies": { "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.4" } }, "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA=="],
 
     "@safe-global/safe-apps-sdk/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+
+    "@safe-global/safe-apps-sdk/viem/isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
 
     "@safe-global/safe-apps-sdk/viem/ox": ["ox@0.6.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA=="],
 
@@ -2139,6 +2203,8 @@
     "@wagmi/cli/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
     "@wagmi/cli/viem/@scure/bip39": ["@scure/bip39@1.5.4", "", { "dependencies": { "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.4" } }, "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA=="],
+
+    "@wagmi/cli/viem/isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
 
     "@wagmi/cli/viem/ox": ["ox@0.6.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA=="],
 
@@ -2163,6 +2229,8 @@
     "@walletconnect/utils/viem/@scure/bip39": ["@scure/bip39@1.5.4", "", { "dependencies": { "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.4" } }, "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA=="],
 
     "@walletconnect/utils/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+
+    "@walletconnect/utils/viem/isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
 
     "@walletconnect/utils/viem/ox": ["ox@0.6.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA=="],
 
@@ -2201,16 +2269,6 @@
     "test-exclude/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "tsc-alias/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
-
-    "viem/@scure/bip32/@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
-
-    "viem/@scure/bip32/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
-
-    "viem/@scure/bip32/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
-
-    "viem/@scure/bip39/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
-
-    "viem/@scure/bip39/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
@@ -2264,6 +2322,16 @@
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
+    "@reown/appkit-common/viem/@scure/bip32/@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
+
+    "@reown/appkit-common/viem/@scure/bip32/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "@reown/appkit-common/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
+
+    "@reown/appkit-common/viem/@scure/bip39/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "@reown/appkit-common/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
+
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.19.2", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.19.2", "@walletconnect/utils": "2.19.2", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.33.0", "events": "3.3.0", "uint8arrays": "3.1.0" } }, "sha512-iu0mgLj51AXcKpdNj8+4EdNNBd/mkNjLEhZn6UMc/r7BM9WbmpPMEydA39WeRLbdLO4kbpmq4wTbiskI1rg+HA=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/@noble/ciphers": ["@noble/ciphers@1.2.1", "", {}, "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA=="],
@@ -2273,6 +2341,16 @@
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.23.2", "", { "dependencies": { "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.7", "ws": "8.18.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA=="],
+
+    "@reown/appkit-controllers/viem/@scure/bip32/@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
+
+    "@reown/appkit-controllers/viem/@scure/bip32/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "@reown/appkit-controllers/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
+
+    "@reown/appkit-controllers/viem/@scure/bip39/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "@reown/appkit-controllers/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.19.2", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.19.2", "@walletconnect/utils": "2.19.2", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.33.0", "events": "3.3.0", "uint8arrays": "3.1.0" } }, "sha512-iu0mgLj51AXcKpdNj8+4EdNNBd/mkNjLEhZn6UMc/r7BM9WbmpPMEydA39WeRLbdLO4kbpmq4wTbiskI1rg+HA=="],
 
@@ -2284,6 +2362,16 @@
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.23.2", "", { "dependencies": { "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.7", "ws": "8.18.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA=="],
 
+    "@reown/appkit-utils/viem/@scure/bip32/@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
+
+    "@reown/appkit-utils/viem/@scure/bip32/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "@reown/appkit-utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
+
+    "@reown/appkit-utils/viem/@scure/bip39/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "@reown/appkit-utils/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
+
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.19.2", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.19.2", "@walletconnect/utils": "2.19.2", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.33.0", "events": "3.3.0", "uint8arrays": "3.1.0" } }, "sha512-iu0mgLj51AXcKpdNj8+4EdNNBd/mkNjLEhZn6UMc/r7BM9WbmpPMEydA39WeRLbdLO4kbpmq4wTbiskI1rg+HA=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/@noble/ciphers": ["@noble/ciphers@1.2.1", "", {}, "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA=="],
@@ -2293,6 +2381,16 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.23.2", "", { "dependencies": { "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.7", "ws": "8.18.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA=="],
+
+    "@reown/appkit/viem/@scure/bip32/@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
+
+    "@reown/appkit/viem/@scure/bip32/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "@reown/appkit/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
+
+    "@reown/appkit/viem/@scure/bip39/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "@reown/appkit/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
 
     "@safe-global/safe-apps-sdk/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
 
@@ -2320,6 +2418,8 @@
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
 
+    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
+
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/ox": ["ox@0.6.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
@@ -2330,6 +2430,8 @@
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
 
+    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
+
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/ox": ["ox@0.6.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
@@ -2339,6 +2441,8 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip39": ["@scure/bip39@1.5.4", "", { "dependencies": { "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.4" } }, "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+
+    "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox": ["ox@0.6.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA=="],
 

--- a/docs/testing/01-architecture.md
+++ b/docs/testing/01-architecture.md
@@ -46,11 +46,15 @@ bun run test
           │     describe.each(getCoreSmartAccounts())(...)  ← matrix over accounts
           │         testWithRpc("...", async ({ rpc }) => { ... })
           │
-          └─ per test() invocation:
-                1. testWithRpc fixture allocates 3 ports
-                2. spawns anvil → setupContracts → alto → mock-paymaster
-                3. awaits the test body with { rpc: { anvilRpc, altoRpc, paymasterRpc } }
-                4. stops all 3 instances, releases ports
+          └─ per worker (shared across all tests in that worker):
+                1. first testWithRpc fixture call triggers getSharedRig()
+                2. spawns anvil → setupContracts → alto → mock-paymaster (once)
+                3. tops up paymaster deposits (1000 ETH per EntryPoint)
+                per test:
+                4. clears alto mempool + resets base fee
+                5. awaits the test body with { rpc: { anvilRpc, altoRpc, paymasterRpc } }
+                worker exit:
+                6. stops all 3 instances (Promise.all)
 ```
 
 Fixture mechanics are detailed in [02-lifecycle.md](./02-lifecycle.md); process details in [03-infrastructure.md](./03-infrastructure.md).
@@ -99,31 +103,32 @@ Field-by-field:
 | `coverage.reporter`         | `CI ? ["lcov"] : ["text","json","html"]`         | Local dev gets HTML + text output; CI produces only lcov (Codecov-friendly).                                           |
 | `coverage.include`          | `["**/permissionless/**"]`                       | Measures coverage of the published package only.                                                                       |
 | `coverage.exclude`          | test files, generated `_cjs`/`_esm`/`_types`, test infra | Keeps coverage numbers honest.                                                                                         |
-| `sequence.concurrent`       | `false`                                          | Tests inside one file run **sequentially**. Multiple parallel Anvil stacks from one file would risk port exhaustion and noisy logs. |
-| `fileParallelism`           | `true`                                           | Separate `.test.ts` files DO run in parallel (in separate workers).                                                    |
+| `sequence.concurrent`       | `false`                                          | Tests inside one file run **sequentially**. This is essential for the shared-rig model: tests in a worker share the same anvil/alto/paymaster trio and clear state between runs. |
+| `fileParallelism`           | `true`                                           | Separate `.test.ts` files DO run in parallel (in separate workers). Each worker gets its own shared rig.               |
 | `environment`               | `"node"`                                         | No jsdom; tests run in raw Node.                                                                                       |
 | `testTimeout`               | `60_000` (60s)                                   | User operations + bundling + receipts are slow; 60s is the per-test cap.                                               |
-| `hookTimeout`               | `45_000` (45s)                                   | The `testWithRpc` fixture setup (anvil + contracts + alto + paymaster) can take tens of seconds cold.                  |
+| `hookTimeout`               | `45_000` (45s)                                   | The `testWithRpc` fixture setup (on first test: anvil + contracts + alto + paymaster) can take tens of seconds cold.   |
 | `include`                   | `join(__dirname, "./**/*.test.ts")`              | Discovery is rooted at `packages/permissionless/` — not the repo root. Tests elsewhere (e.g. `packages/mock-paymaster/`) are **not** picked up. |
 | `env`                       | `loadEnv("test", process.cwd())`                 | Reads `.env.test`, `.env.test.local`, `.env`, `.env.local` from the CWD and exposes `VITE_*` vars to tests.            |
 
 ### Parallelism model
 
-- **File-level:** parallel. Each `.test.ts` file runs in its own worker, which means each has its own module-level state (including the `ports: number[]` tracker in `testWithRpc.ts:80`). Workers do not share a port list, but `get-port` asks the OS for a free port, so real collisions are rare.
-- **Test-level (inside a file):** serial. Each `testWithRpc(...)` inside a file waits for the previous one to tear down before the next starts. That means **within one file, there is never more than one Anvil/Alto/paymaster trio alive at once**.
+- **File-level:** parallel. Each `.test.ts` file runs in its own worker, which means each has its own shared rig (anvil + alto + paymaster trio). Workers do not share processes or ports.
+- **Test-level (inside a file):** serial. Each `testWithRpc(...)` inside a file waits for the previous one to complete before the next starts. This is critical because tests share the same anvil/alto/paymaster trio within a worker.
 
 Combined: at any instant, concurrency ≈ number of `.test.ts` files currently in flight. With Vitest's default worker count (≈ CPU cores), you typically have 4–8 parallel stacks.
 
 ### Why `hookTimeout` is 45s
 
-`testWithRpc` setup does, in order:
+The first `testWithRpc` call in a worker triggers `getSharedRig()`, which does:
 1. Allocate 3 free ports (ms).
 2. Start Anvil (~1–3s cold).
 3. Call `setupContracts(anvilRpc)` which issues **~80+ transactions** to the deterministic deployer and a few impersonation + `setCode` calls. With all txns batched via `Promise.all`, this typically lands in 2–8s but can spike.
-4. Start Alto (subprocess, waits for `"Server listening at"` message; ~2–5s).
+4. Start Alto with debug endpoints enabled (subprocess, waits for `"Server listening at"` message; ~2–5s).
 5. Start the paymaster (Fastify boot; ~1s).
+6. Top up paymaster deposits (~1s).
 
-On a slow machine or noisy CI runner, cumulative setup > 30s is possible; 45s is the margin.
+On a slow machine or noisy CI runner, cumulative setup > 30s is possible; 45s is the margin. Subsequent tests in the same worker skip this setup entirely (the rig is already running), so only the first test pays the cold-start cost.
 
 ## File layout
 
@@ -152,7 +157,7 @@ Non-exhaustive — see `packages/permissionless/**/*.test.ts` for the full set.
 
 | Directory / file                          | Purpose                                                                 |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
-| `src/testWithRpc.ts`                      | The `testWithRpc` fixture — starts/stops anvil + alto + paymaster.      |
+| `src/testWithRpc.ts`                      | The `testWithRpc` fixture — shared per-worker rig, per-test reset, `createAutoBundleTransport`. |
 | `src/utils.ts`                            | All viem/Pimlico/smart-account helpers. Re-read this often.             |
 | `src/types.ts`                            | `AAParamType<entryPointVersion>`.                                       |
 | `mock-aa-infra/alto/instance.ts`          | `alto(...)` prool instance factory.                                     |
@@ -171,7 +176,7 @@ It is imported from test files by **relative path** (e.g. `"../../../permissionl
 | You want to…                             | Open                                                                      |
 | ---------------------------------------- | ------------------------------------------------------------------------- |
 | Change how tests are discovered / timed out | `packages/permissionless/vitest.config.ts`                                |
-| Change the per-test setup/teardown       | `packages/permissionless-test/src/testWithRpc.ts`                         |
+| Change the per-worker setup or per-test reset | `packages/permissionless-test/src/testWithRpc.ts`                         |
 | Add a new viem client helper             | `packages/permissionless-test/src/utils.ts`                               |
 | Add a new smart account type             | `packages/permissionless-test/src/utils.ts` + `mock-aa-infra/alto/constants/accounts/` + `mock-aa-infra/alto/index.ts` |
 | Change how the bundler is started        | `packages/permissionless-test/mock-aa-infra/alto/instance.ts`             |

--- a/docs/testing/02-lifecycle.md
+++ b/docs/testing/02-lifecycle.md
@@ -15,11 +15,9 @@ testWithRpc("my test", async ({ rpc }) => {
 })
 ```
 
-The fixture definition (`packages/permissionless-test/src/testWithRpc.ts:80`):
+The fixture definition (`packages/permissionless-test/src/testWithRpc.ts`):
 
 ```ts
-let ports: number[] = []
-
 export const testWithRpc = test.extend<{
     rpc: {
         anvilRpc: string
@@ -27,142 +25,275 @@ export const testWithRpc = test.extend<{
         paymasterRpc: string
     }
 }>({
+    // biome-ignore lint/correctness/noEmptyPattern: Needed in vitest :/
     rpc: async ({}, use) => {
-        const altoPort = await getPort({ exclude: ports })
-        ports.push(altoPort)
-        const paymasterPort = await getPort({ exclude: ports })
-        ports.push(paymasterPort)
-        const anvilPort = await getPort({ exclude: ports })
-        ports.push(anvilPort)
+        const rig = await getSharedRig()
 
-        const anvilRpc     = `http://localhost:${anvilPort}`
-        const altoRpc      = `http://localhost:${altoPort}`
-        const paymasterRpc = `http://localhost:${paymasterPort}`
+        // Clear alto's mempool + reputation between tests
+        await clearAltoState(rig.altoRpc)
 
-        const instances = await getInstances({ anvilPort, altoPort, paymasterPort })
+        // Reset base fee to prevent inflation from accumulated mined blocks.
+        const testClient = createTestClient({
+            mode: "anvil",
+            chain: foundry,
+            transport: http(rig.anvilRpc)
+        })
+        await testClient.setNextBlockBaseFeePerGas({
+            baseFeePerGas: 1000000000n
+        })
+        await testClient.mine({ blocks: 1 })
 
-        await use({ anvilRpc, altoRpc, paymasterRpc })
-
-        await Promise.all(instances.map((instance) => instance.stop()))
-        ports = ports.filter(
-            (port) => port !== altoPort || port !== anvilPort || port !== paymasterPort
-        )
+        await use({
+            anvilRpc: rig.anvilRpc,
+            altoRpc: rig.altoRpc,
+            paymasterRpc: rig.paymasterRpc
+        })
     }
 })
 ```
 
-Three things to notice:
+Key things to notice:
 
-1. The whole fixture is a single async function with a single `use(...)` call in the middle. Everything before `use` is **setup**; everything after is **teardown**. Vitest awaits setup, runs the test body (which receives the argument passed to `use`), then awaits teardown.
-2. `ports` is a **module-level** `let` array. Each Vitest worker has its own module scope, so this tracker is per-worker.
-3. `getInstances(...)` (defined in the same file, `testWithRpc.ts:14`) is where the three processes are actually spawned — covered in [03-infrastructure.md](./03-infrastructure.md).
+1. **Shared rig:** `getSharedRig()` returns a lazily-initialized singleton per worker — the anvil/alto/paymaster trio is only started once and reused for all tests in that worker.
+2. **Per-test reset:** Before each test, Alto's mempool and reputation are cleared, and the base fee is reset to 1 gwei.
+3. **No per-test teardown:** After `use()` returns, there is no cleanup. The shared trio stays up for the next test. Cleanup happens at worker exit.
+
+## The shared rig
+
+The shared rig is a module-level lazy singleton (`testWithRpc.ts`):
+
+```ts
+type SharedRig = {
+    anvilRpc: string
+    altoRpc: string
+    paymasterRpc: string
+    anvilInstance: Awaited<ReturnType<typeof anvil>>
+    altoInstance: Awaited<ReturnType<typeof alto>>
+    paymasterInstance: Awaited<ReturnType<typeof paymaster>>
+}
+
+let sharedRigPromise: Promise<SharedRig> | null = null
+
+async function getSharedRig(): Promise<SharedRig> {
+    if (sharedRigPromise) return sharedRigPromise
+    sharedRigPromise = (async () => {
+        // ... allocate ports, start processes, deploy contracts, top up deposits
+    })()
+    return sharedRigPromise
+}
+```
+
+Each Vitest worker has its own module scope, so the `sharedRigPromise` singleton is per-worker. Within one worker, tests are serial (`sequence.concurrent: false`), so there are no race conditions on the shared mutable state.
 
 ## Port allocation
 
-`get-port` is used three times in a row, each excluding the previously-allocated ports from the search:
+Ports are allocated once per worker during rig initialization:
 
 ```ts
-const altoPort      = await getPort({ exclude: ports })
-ports.push(altoPort)
-const paymasterPort = await getPort({ exclude: ports })
-ports.push(paymasterPort)
-const anvilPort     = await getPort({ exclude: ports })
-ports.push(anvilPort)
+const anvilPort = await getPort()
+const altoPort = await getPort({ exclude: [anvilPort] })
+const paymasterPort = await getPort({ exclude: [anvilPort, altoPort] })
 ```
 
-`get-port` asks the OS for an available port (by briefly binding to port `0`), so the main source of conflict is an **already-in-use Vitest fixture in the same worker** — which the `exclude` list handles.
+`get-port` asks the OS for an available port. Each subsequent call excludes previously allocated ports to avoid collisions before the processes actually bind to them. Since ports are only allocated once per worker (not per test), the allocation logic is simple and collision-free.
 
-### Why `exclude` matters
+## Setup sequence (once per worker)
 
-Without it, the second call could return the port just allocated by the first (since nothing is listening on it yet — the Anvil process hasn't started). Pushing each port onto the tracker and passing `exclude: ports` forces `get-port` to skip them.
-
-### The teardown filter quirk
-
-The filter on teardown (`testWithRpc.ts:121`) is:
-
-```ts
-ports = ports.filter(
-    (port) => port !== altoPort || port !== anvilPort || port !== paymasterPort
-)
-```
-
-With three distinct ports, for any element `p` in the array, at most **one** of `p !== altoPort`, `p !== anvilPort`, `p !== paymasterPort` is false — the other two are true, so the `||` short-circuits to true. Every element is kept. In other words, **ports are never removed from the tracker**.
-
-In practice this is harmless because:
-- Each Vitest worker serialises tests within a file, so the tracker only grows by 3 per test in that worker.
-- `get-port` still asks the OS for a genuinely free port each call; the `exclude` list just adds ports to avoid. Past ports that are now closed don't block the OS from reusing them for later tests — but they do grow the `exclude` array.
-
-If you touch this file, a correct filter would be `p !== altoPort && p !== anvilPort && p !== paymasterPort`. This doc describes current behaviour; any change is out of scope here.
-
-## Setup sequence
-
-`getInstances` (`testWithRpc.ts:14–78`) runs this order — and the order matters:
+`getSharedRig()` runs this order — and the order matters:
 
 ```
-┌── getInstances ──────────────────────────────────────────────────┐
-│                                                                  │
-│  1. Build AnvilInstance   (forked if VITE_FORK_RPC_URL is set)   │
-│  2. Build AltoInstance    (rpcUrl = http://localhost:anvilPort)  │
-│  3. Build paymasterInstance (anvilRpc + altoRpc + port)          │
-│  4. await anvilInstance.start()                                  │
-│  5. if (!forkUrl) await setupContracts(anvilRpc)                 │
-│  6. await altoInstance.start()                                   │
-│  7. await paymasterInstance.start()                              │
-│  8. return [anvilInstance, altoInstance, paymasterInstance]      │
-│                                                                  │
-└──────────────────────────────────────────────────────────────────┘
+┌── getSharedRig ──────────────────────────────────────────────┐
+│                                                               │
+│  1. Allocate 3 ports (anvil, alto, paymaster)                 │
+│  2. Start Anvil (forked if VITE_FORK_RPC_URL is set)          │
+│  3. if (!forkUrl) setupContracts(anvilRpc)                    │
+│  4. Start Alto (with enableDebugEndpoints: true)              │
+│  5. Start mock paymaster                                      │
+│  6. Top up paymaster deposits (1000 ETH per EntryPoint)       │
+│     └─ depositTo() on each EntryPoint for each paymaster      │
+│        address (v0.6, v0.7, v0.8)                             │
+│  7. Return shared rig object                                  │
+│                                                               │
+└───────────────────────────────────────────────────────────────┘
 ```
 
 Why this order:
 
 - **Anvil must be up before contracts are deployed** — `setupContracts` issues real JSON-RPC transactions.
-- **Contracts must exist before Alto starts.** Alto queries the EntryPoint and simulation contracts on boot; if they don't exist yet its RPC will respond with errors when the test tries to `eth_supportedEntryPoints`, etc.
-- **Alto must be up before the paymaster starts.** The paymaster calls Alto during setup and during sponsorship. See `packages/mock-paymaster/index.ts:33` where `setup({ anvilRpc, paymasterSigner })` runs before Fastify starts listening.
+- **Contracts must exist before Alto starts.** Alto queries the EntryPoint and simulation contracts on boot.
+- **Alto must be up before the paymaster starts.** The paymaster calls Alto during setup and during sponsorship.
+- **Paymaster deposits are topped up last.** The paymaster's `setup()` deploys paymaster contracts; deposits are then added via the EntryPoint's `depositTo()` function.
 - If `VITE_FORK_RPC_URL` is set, `setupContracts` is **skipped** — the forked chain already contains all the deployed contracts. See [06-ci-and-running.md § Fork mode](./06-ci-and-running.md#fork-mode).
 
-Contract deployment details are in [04-contracts.md](./04-contracts.md). Process-level details (how `prool` spawns subprocesses, what readiness signals each uses) are in [03-infrastructure.md](./03-infrastructure.md).
+Contract deployment details are in [04-contracts.md](./04-contracts.md). Process-level details in [03-infrastructure.md](./03-infrastructure.md).
 
-## Teardown sequence
+### Paymaster deposit top-up
 
-After the test body finishes (whether it passed, failed, or threw):
+The mock paymaster's initial `setup()` deposits 50 ETH per EntryPoint, which can be exhausted across many tests sharing the same chain. To prevent "AA31 paymaster deposit too low" errors, the shared rig tops up each paymaster with 1000 ETH:
 
 ```ts
-await Promise.all(instances.map((instance) => instance.stop()))
+const paymasterAddresses = [
+    { entryPoint: entryPoint06Address, paymaster: getSingletonPaymaster06Address(signerAddress) },
+    { entryPoint: entryPoint07Address, paymaster: getSingletonPaymaster07Address(signerAddress) },
+    { entryPoint: entryPoint08Address, paymaster: getSingletonPaymaster08Address(signerAddress) }
+]
+for (const { entryPoint, paymaster: pm } of paymasterAddresses) {
+    await walletClient.writeContract({
+        address: entryPoint,
+        abi: depositToAbi,
+        functionName: "depositTo",
+        args: [pm],
+        value: parseEther("1000")
+    })
+}
 ```
 
-- All three instances are stopped in parallel.
-- `anvilInstance.stop()` and `altoInstance.stop()` kill their subprocesses (via `prool`).
-- `paymasterInstance.stop()` calls `app.close()` on the Fastify server (`packages/mock-paymaster/index.ts:57`).
-- After this, the port-tracker update runs (and as noted above, leaves the tracker unchanged).
+The paymaster signer key (`0xbbbb…bbbb`) is used to compute the deterministic paymaster addresses via `getSingletonPaymaster0{6,7,8}Address()` from `packages/mock-paymaster/constants.ts`.
 
-If the test body throws **before** `use`'s callback resolves, Vitest still runs teardown. If the teardown itself throws, Vitest reports it as a setup/teardown failure on the test.
+## Per-test reset
+
+Before each test body runs, two reset operations occur:
+
+### 1. Clear Alto state
+
+```ts
+async function clearAltoState(altoRpc: string): Promise<void> {
+    await fetch(altoRpc, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            jsonrpc: "2.0",
+            method: "debug_bundler_clearState",
+            params: [],
+            id: 1
+        })
+    })
+}
+```
+
+This clears Alto's in-memory mempool and reputation tracking. It requires `enableDebugEndpoints: true` on the Alto instance.
+
+### 2. Reset base fee
+
+```ts
+await testClient.setNextBlockBaseFeePerGas({ baseFeePerGas: 1000000000n }) // 1 gwei
+await testClient.mine({ blocks: 1 })
+```
+
+With shared infrastructure, each test that sends user operations triggers `debug_bundler_sendBundleNow` followed by `mine({ blocks: 1 })`. Each non-empty mined block increases Anvil's EIP-1559 base fee. Without resetting, the base fee can grow to hundreds of thousands of gwei after many tests, causing "AA31 paymaster deposit too low" errors because the gas cost per user operation becomes enormous.
+
+## Auto-bundle transport
+
+The file also exports `createAutoBundleTransport`, a custom viem transport that makes bundling deterministic and near-instant:
+
+```ts
+function createAutoBundleTransport(altoRpc: string, anvilRpc: string) {
+    const baseTransport = http(altoRpc)
+
+    return custom({
+        async request({ method, params }) {
+            const transport = baseTransport({ chain: foundry })
+            const result = await transport.request({ method, params } as any)
+
+            // After a user op is submitted, immediately bundle + mine
+            if (method === "eth_sendUserOperation") {
+                await fetch(altoRpc, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        jsonrpc: "2.0",
+                        method: "debug_bundler_sendBundleNow",
+                        params: [],
+                        id: 1
+                    })
+                })
+                const testClient = createTestClient({
+                    mode: "anvil",
+                    chain: foundry,
+                    transport: http(anvilRpc)
+                })
+                await testClient.mine({ blocks: 1 })
+            }
+
+            return result
+        }
+    })
+}
+```
+
+This transport wraps Alto's HTTP endpoint and intercepts `eth_sendUserOperation` calls. After forwarding the call, it immediately:
+1. Triggers `debug_bundler_sendBundleNow` to bundle the pending user operation.
+2. Mines a block to include the bundle transaction.
+
+This eliminates the ~4s wait for Alto's periodic auto-bundling, making each user operation resolve in ~500ms instead of ~4000ms. The `getBundlerClient` and `getSmartAccountClient` helpers in `utils.ts` use this transport by default.
+
+## Worker-level cleanup
+
+```ts
+process.on("beforeExit", async () => {
+    if (!sharedRigPromise) return
+    const rig = await sharedRigPromise
+    await Promise.all([
+        rig.altoInstance.stop(),
+        rig.paymasterInstance.stop(),
+        rig.anvilInstance.stop()
+    ])
+    sharedRigPromise = null
+})
+```
+
+When the worker process exits, all three instances are stopped in parallel. This ensures no orphaned anvil/alto processes are left behind.
 
 ## State isolation guarantees
 
-Because every test gets a fresh trio of processes:
+Because all tests in a worker share the same trio of processes, isolation relies on different mechanisms than a per-test model:
 
-| Concern                   | Guarantee                                                                                  |
-| ------------------------- | ------------------------------------------------------------------------------------------ |
-| Chain state               | Fresh genesis (unless fork mode). Block number resets.                                     |
-| Account nonces            | Anvil account `0xac097…` and the Rhinestone/Kernel/Alchemy impersonated addresses all start from 0 (or forked nonce). |
-| Deployed contract state   | All ERC-4337 contracts are newly deployed → storage is exactly what `setupContracts` writes. |
-| Smart-account deployments | Every test creates its own smart account (by private key); counterfactual addresses differ  per-test because `privateKey` defaults to `generatePrivateKey()` in most helpers. |
-| Bundler mempool           | Fresh Alto, empty mempool.                                                                 |
-| Paymaster nonces          | Fresh wallet tied to the paymaster private key `0xbbbb…bbbb`.                              |
-| Ports                     | Distinct for every concurrent test.                                                        |
+| Concern                   | How it's isolated                                                                                  |
+| ------------------------- | -------------------------------------------------------------------------------------------------- |
+| Smart-account addresses   | Each `describe.each(getCoreSmartAccounts())` block generates a fresh `privateKey = generatePrivateKey()`, so counterfactual addresses differ per account type and per test run. |
+| Bundler mempool           | `debug_bundler_clearState` is called before each test, clearing pending user operations and reputation tracking. |
+| Base fee                  | Reset to 1 gwei before each test to prevent EIP-1559 inflation from prior mined blocks.            |
+| Paymaster deposits        | Topped up to 1000 ETH per EntryPoint at worker startup. Sufficient for hundreds of tests.          |
+| Chain state (storage, nonces, balances) | **Not reset** between tests. Tests rely on fresh private keys generating unique counterfactual addresses to avoid collisions. On-chain state from prior tests persists but doesn't interfere because each test operates on different accounts. |
+| Deployed contract state   | Contracts deployed by `setupContracts` persist across tests. This is desirable — contract setup is the expensive part (~2-8s). |
+| Ports                     | Allocated once per worker, distinct from other workers.                                            |
 
-**Cross-test interference is impossible by construction** — there is no shared mutable state between tests, because there are no shared processes.
+### Important: private key isolation
+
+Tests **must** use `generatePrivateKey()` (from `viem/accounts`) to create unique keys per test or per `describe.each` block. Using a hardcoded private key across tests causes cross-test contamination because:
+- The same key produces the same counterfactual smart-account address.
+- One test's deployment or EIP-7702 delegation persists and interferes with later tests using that address.
+
+The standard pattern:
+
+```ts
+describe.each(getCoreSmartAccounts())(
+    "myTest $name",
+    ({ getSmartAccountClient, ... }) => {
+        const privateKey = generatePrivateKey() // Fresh key per account type
+        testWithRpc("test_v07", async ({ rpc }) => {
+            const smartClient = await getSmartAccountClient({
+                entryPoint: { version: "0.7" },
+                privateKey,
+                ...rpc
+            })
+            // ...
+        })
+    }
+)
+```
 
 ## Interaction with `describe.each`
 
-Many tests use `describe.each(getCoreSmartAccounts())` to matrix across every smart-account type. For example, `packages/permissionless/actions/smartAccount/sendTransaction.test.ts:14`:
+Many tests use `describe.each(getCoreSmartAccounts())` to matrix across every smart-account type. For example:
 
 ```ts
 describe.each(getCoreSmartAccounts())(
     "sendTransaction $name",
     ({ getSmartAccountClient, supportsEntryPointV06, supportsEntryPointV07, supportsEntryPointV08, isEip7702Compliant }) => {
+        const privateKey = generatePrivateKey()
         testWithRpc.skipIf(!supportsEntryPointV06)("sendTransaction_v06", async ({ rpc }) => {
-            const smartClient = await getSmartAccountClient({ entryPoint: { version: "0.6" }, ...rpc })
+            const smartClient = await getSmartAccountClient({ entryPoint: { version: "0.6" }, privateKey, ...rpc })
             // ...
         })
         // ...
@@ -170,16 +301,16 @@ describe.each(getCoreSmartAccounts())(
 )
 ```
 
-Each generated `testWithRpc(...)` call gets its **own** `getInstances` call, not a shared one. So `sendTransaction Safe / sendTransaction_v06` and `sendTransaction Kernel / sendTransaction_v06` each spawn their own anvil/alto/paymaster trio. This is fine because tests within one file run serially ([see 01-architecture.md § Parallelism model](./01-architecture.md#parallelism-model)).
+All generated `testWithRpc(...)` calls share the same anvil/alto/paymaster trio. Each account type within the `describe.each` gets its own `privateKey`, ensuring different counterfactual addresses. Tests within one file run serially ([see 01-architecture.md § Parallelism model](./01-architecture.md#parallelism-model)).
 
-`testWithRpc.skipIf(!supportsEntryPointV06)` is a thin wrapper around Vitest's `test.skipIf`: it short-circuits the whole fixture when the predicate is true, so skipped tests don't pay the setup cost.
+`testWithRpc.skipIf(!supportsEntryPointV06)` is a thin wrapper around Vitest's `test.skipIf`: it short-circuits the whole fixture when the predicate is true, so skipped tests don't pay the reset cost.
 
 ## What runs on each port
 
 | Port           | Process              | Primary RPC surface                                                              |
 | -------------- | -------------------- | -------------------------------------------------------------------------------- |
 | `anvilPort`    | Anvil (via `prool`)  | Standard JSON-RPC (`eth_*`, `anvil_*` cheat codes).                              |
-| `altoPort`     | Alto bundler         | ERC-4337 bundler methods (`eth_sendUserOperation`, `eth_estimateUserOperationGas`, `pimlico_*`, etc.). |
+| `altoPort`     | Alto bundler         | ERC-4337 bundler methods (`eth_sendUserOperation`, `eth_estimateUserOperationGas`, `pimlico_*`, `debug_bundler_*`). |
 | `paymasterPort`| Fastify mock paymaster | `POST /` (RPC handler: `pm_sponsorUserOperation`, `pimlico_getTokenQuotes`, …) and `GET /ping` (health). |
 
 The helper functions that understand these URLs are all in `packages/permissionless-test/src/utils.ts` — covered in [05-clients-accounts.md](./05-clients-accounts.md).

--- a/docs/testing/03-infrastructure.md
+++ b/docs/testing/03-infrastructure.md
@@ -1,12 +1,12 @@
 # 03 — Infrastructure (Anvil, Alto, mock paymaster)
 
-Three processes are spawned per test. This document describes how each is configured, how they are started and stopped, and what guarantees each provides.
+Three processes are spawned **once per Vitest worker** and shared across all tests in that worker. This document describes how each is configured, how they are started and stopped, and what guarantees each provides.
 
 All three are built on [`prool`](https://github.com/wevm/prool), a small library for orchestrating local dev processes (it provides `defineInstance` + an `execa`-based process manager). Each instance exposes `.start()` and `.stop()`.
 
 ## Anvil
 
-Spawned in `packages/permissionless-test/src/testWithRpc.ts:29` via `prool/instances`'s built-in `anvil` factory:
+Spawned in `packages/permissionless-test/src/testWithRpc.ts` inside `getSharedRig()` via `prool/instances`'s built-in `anvil` factory:
 
 ```ts
 import { anvil } from "prool/instances"
@@ -29,7 +29,7 @@ const anvilInstance = forkUrl
 | ------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `chainId`     | `foundry.id` (`31337`)                              | Same chainId whether forked or not. All viem clients use `chain: foundry`.                         |
 | `hardfork`    | `"Prague"`                                          | Pinned to Prague for consistent behavior (EIP-7702 is Prague-era; some tests rely on its opcodes). |
-| `port`        | `anvilPort` (dynamic)                               | See [02-lifecycle.md § Port allocation](./02-lifecycle.md#port-allocation).                        |
+| `port`        | `anvilPort` (dynamic)                               | Allocated once per worker via `get-port`. See [02-lifecycle.md § Port allocation](./02-lifecycle.md#port-allocation). |
 | `forkUrl`     | `process.env.VITE_FORK_RPC_URL` (optional)          | If set, Anvil boots as a fork of that chain at its tip.                                            |
 
 ### Default funded account
@@ -42,12 +42,22 @@ Anvil ships with 10 pre-funded accounts from the mnemonic `test test test test t
 This key is used:
 
 1. As the default signer for `walletClient` in `setupContracts` (`mock-aa-infra/alto/index.ts:107`).
-2. As Alto's `executorPrivateKeys[0]` and `utilityPrivateKey` (`testWithRpc.ts:22`).
-3. Indirectly via `getAnvilWalletClient({ addressIndex: 0 })` helper.
+2. As Alto's `executorPrivateKeys[0]` and `utilityPrivateKey`.
+3. For topping up paymaster deposits in `getSharedRig()`.
+4. Indirectly via `getAnvilWalletClient({ addressIndex: 0 })` helper.
+
+### Base fee management
+
+With the shared-per-worker model, many blocks are mined across tests (each `eth_sendUserOperation` triggers `debug_bundler_sendBundleNow` + `mine`). Anvil's EIP-1559 base fee increases with each non-empty block. To prevent gas costs from spiraling, the `testWithRpc` fixture resets the base fee to 1 gwei before each test:
+
+```ts
+await testClient.setNextBlockBaseFeePerGas({ baseFeePerGas: 1000000000n })
+await testClient.mine({ blocks: 1 })
+```
 
 ### Fork mode
 
-If `VITE_FORK_RPC_URL` is set in `.env.test` (or process env), Anvil starts as a fork of that URL. The fixture also **skips** `setupContracts(anvilRpc)` (`testWithRpc.ts:70`) because a live network already has the EntryPoints, factories, etc. deployed at their deterministic addresses.
+If `VITE_FORK_RPC_URL` is set in `.env.test` (or process env), Anvil starts as a fork of that URL. The fixture also **skips** `setupContracts(anvilRpc)` because a live network already has the EntryPoints, factories, etc. deployed at their deterministic addresses.
 
 See [06-ci-and-running.md § Fork mode](./06-ci-and-running.md#fork-mode) for usage.
 
@@ -55,7 +65,7 @@ See [06-ci-and-running.md § Fork mode](./06-ci-and-running.md#fork-mode) for us
 
 The Alto wrapper lives in `packages/permissionless-test/mock-aa-infra/alto/instance.ts`. It is a **custom `prool` instance** (not shipped by `prool` itself) built with `defineInstance` + `execa`.
 
-The test fixture constructs Alto with (`testWithRpc.ts:42`):
+The shared rig constructs Alto with:
 
 ```ts
 const altoInstance = alto({
@@ -68,7 +78,8 @@ const altoInstance = alto({
     executorPrivateKeys: [anvilPrivateKey],
     safeMode: false,
     port: altoPort,
-    utilityPrivateKey: anvilPrivateKey
+    utilityPrivateKey: anvilPrivateKey,
+    enableDebugEndpoints: true
 })
 ```
 
@@ -79,13 +90,21 @@ const altoInstance = alto({
 | `executorPrivateKeys`    | `[anvilPrivateKey]`                        | The account(s) that sign handleOps bundle transactions.                                               |
 | `utilityPrivateKey`      | `anvilPrivateKey`                          | Alto's utility wallet (refills executors, deploys supporting contracts).                              |
 | `safeMode`               | `false`                                    | Skips ERC-4337 validity-rule enforcement. Test-only convenience; do not copy into production configs. |
-| `port`                   | `altoPort`                                 | Dynamic per test.                                                                                     |
+| `port`                   | `altoPort`                                 | Allocated once per worker via `get-port`.                                                             |
+| `enableDebugEndpoints`   | `true`                                     | **Required** for `debug_bundler_clearState` (per-test mempool reset) and `debug_bundler_sendBundleNow` (deterministic bundling via `createAutoBundleTransport`). |
 
 Using the anvil account 0 key for **both** executor and utility is fine: that account is funded with 10,000 ETH by Anvil, so gas costs are unbounded.
 
+### Debug endpoints
+
+Two Alto debug endpoints are critical to the shared-rig model:
+
+- **`debug_bundler_clearState`**: Clears Alto's in-memory mempool and reputation tracking. Called before each test to prevent state leakage.
+- **`debug_bundler_sendBundleNow`**: Immediately bundles all pending user operations. Used by `createAutoBundleTransport` to make bundling deterministic rather than waiting for Alto's periodic timer (~4s).
+
 ### How `alto` is spawned
 
-From `packages/permissionless-test/mock-aa-infra/alto/instance.ts:244`:
+From `packages/permissionless-test/mock-aa-infra/alto/instance.ts`:
 
 ```ts
 export const alto = defineInstance((parameters?: AltoParameters) => {
@@ -113,7 +132,6 @@ export const alto = defineInstance((parameters?: AltoParameters) => {
                 ($) => $`${binary} ${toArgs({ port, ...args })}`,
                 {
                     ...options,
-                    // Resolve when the process is listening via a "Server listening at" message.
                     resolver({ process, reject, resolve }) {
                         process.stdout.on("data", (data) => {
                             const message = data.toString()
@@ -135,33 +153,13 @@ Key observations:
 1. The binary is resolved from the `@pimlico/alto` npm package's `cli/alto.js` entrypoint. It runs via `node`, not a standalone binary.
 2. Arguments are built by `toArgs(...)` from `prool` — it turns the `AltoParameters` object into a CLI argument list.
 3. **Readiness signal: the literal string `"Server listening at"` on stdout.** The `start()` promise only resolves once this appears, which means tests can safely make RPC calls against Alto as soon as the fixture's `await use(...)` begins.
-4. No stderr-based rejection is wired up (the line `process.stderr.on('data', reject)` is commented out). A crashing Alto will hang until Vitest's `hookTimeout` (45s) fires.
+4. No stderr-based rejection is wired up. A crashing Alto will hang until Vitest's `hookTimeout` (45s) fires.
 
-`AltoParameters` (`instance.ts:6–227`) has ~40 fields mirroring Alto's CLI. The test fixture only sets the handful shown above; everything else uses Alto's defaults.
-
-### Readiness helper
-
-Although `prool` already waits for `"Server listening at"`, there's also an independent readiness loop for tests that want belt-and-braces (`packages/permissionless-test/src/utils.ts:61`):
-
-```ts
-export const ensureBundlerIsReady = async ({ altoRpc, anvilRpc }) => {
-    const bundlerClient = getBundlerClient({ altoRpc, anvilRpc, entryPoint: { version: "0.6" } })
-    while (true) {
-        try {
-            await bundlerClient.getChainId()
-            return
-        } catch {
-            await new Promise((resolve) => setTimeout(resolve, 1000))
-        }
-    }
-}
-```
-
-It polls `getChainId()` against Alto until it responds. Most tests don't need this because the fixture already waits for Alto to start.
+`AltoParameters` has ~40 fields mirroring Alto's CLI. The shared rig only sets the handful shown above; everything else uses Alto's defaults.
 
 ## Mock paymaster
 
-The mock paymaster is in its own workspace package `packages/mock-paymaster/`. Entry file `packages/mock-paymaster/index.ts:10`:
+The mock paymaster is in its own workspace package `packages/mock-paymaster/`. Entry file `packages/mock-paymaster/index.ts`:
 
 ```ts
 export const paymaster = defineInstance(
@@ -206,28 +204,13 @@ export const paymaster = defineInstance(
 
 ### Paymaster signer
 
-The paymaster uses a fixed key: `0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`. Its Ethereum address is constant and well-known; the paymaster's `setup(...)` call (from `packages/mock-paymaster/setup.ts`) is responsible for deploying a paymaster contract owned by this key against the local anvil, funding it, etc.
+The paymaster uses a fixed key: `0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`. Its Ethereum address is constant and well-known; the paymaster's `setup(...)` call (from `packages/mock-paymaster/setup.ts`) deploys paymaster contracts owned by this key against the local anvil, deposits an initial 50 ETH per EntryPoint, and configures the signer.
 
-### Readiness helper
+The shared rig then tops up the deposit to 1000 ETH per EntryPoint to ensure deposits don't run out across many tests. See [02-lifecycle.md § Paymaster deposit top-up](./02-lifecycle.md#paymaster-deposit-top-up).
 
-Unlike Alto, `paymaster.start()` does **not** have a stdout-based readiness signal — `app.listen(...)` already awaits server-start, so when `paymasterInstance.start()` resolves, the server is accepting connections. There is still a polling helper in `packages/permissionless-test/src/utils.ts:83`:
+### Statelessness
 
-```ts
-export const ensurePaymasterIsReady = async () => {
-    while (true) {
-        try {
-            const res = await fetch(`${PAYMASTER_RPC}/ping`)
-            const data = await res.json()
-            if (data.message !== "pong") throw new Error("nope")
-            return
-        } catch {
-            await new Promise((resolve) => setTimeout(resolve, 1000))
-        }
-    }
-}
-```
-
-**Caveat:** this helper uses the constant `PAYMASTER_RPC = "http://localhost:3000"` (`utils.ts:59`), **not** the dynamically-allocated `paymasterRpc` from the fixture. So it only works if a paymaster happens to be listening on port 3000. Prefer relying on the fixture's guarantee that the server is live by the time the test body runs.
+The mock paymaster's Fastify server is effectively stateless per request — it signs sponsorships on demand from the fixed `0xbbbb…bbbb` key. No explicit reset is needed between tests beyond the Alto mempool clear and base fee reset handled by the `testWithRpc` fixture.
 
 ## Startup ordering & dependencies
 
@@ -251,6 +234,25 @@ export const ensurePaymasterIsReady = async () => {
            every smart-account factory before Alto boots.
 ```
 
-Practical upshot: if you ever rearrange `getInstances`, keep the order **anvil → contracts → alto → paymaster**. Swapping any two will cause one of the processes to make RPC calls against a counterparty that doesn't exist or isn't ready yet.
+Practical upshot: if you ever rearrange `getSharedRig`, keep the order **anvil → contracts → alto → paymaster → deposit top-up**. Swapping any two will cause one of the processes to make RPC calls against a counterparty that doesn't exist or isn't ready yet.
+
+## Shutdown
+
+When the worker process exits:
+
+```ts
+process.on("beforeExit", async () => {
+    if (!sharedRigPromise) return
+    const rig = await sharedRigPromise
+    await Promise.all([
+        rig.altoInstance.stop(),
+        rig.paymasterInstance.stop(),
+        rig.anvilInstance.stop()
+    ])
+    sharedRigPromise = null
+})
+```
+
+All three instances are stopped in parallel. `anvilInstance.stop()` and `altoInstance.stop()` kill their subprocesses (via `prool`). `paymasterInstance.stop()` calls `app.close()` on the Fastify server.
 
 → Next: [04-contracts.md](./04-contracts.md)

--- a/docs/testing/06-ci-and-running.md
+++ b/docs/testing/06-ci-and-running.md
@@ -18,7 +18,7 @@ From `package.json:92–94`:
 | `bun run test:ci-no-coverage` | Quick full CI-style run locally | one-shot | none                       | `--pool=forks`  |
 | `bun run test:ci`        | What CI runs          | one-shot            | lcov only                   | `--pool=forks`  |
 
-Why `--pool=forks`? The default Vitest pool uses worker **threads**; `forks` uses worker **processes**. Because each test spawns multiple child processes (Anvil, Alto, Fastify) and relies on `prool` signal handling, process-pool isolation is safer and more reliable, at the cost of slightly higher memory usage.
+Why `--pool=forks`? The default Vitest pool uses worker **threads**; `forks` uses worker **processes**. Because each worker spawns multiple child processes (Anvil, Alto, Fastify) shared across tests and relies on `prool` signal handling, process-pool isolation is safer and more reliable, at the cost of slightly higher memory usage.
 
 The `CI=true &&` prefix in the CI scripts sets the environment variable so `vitest.config.ts:10` picks the lcov-only reporter:
 
@@ -67,7 +67,7 @@ Loaded by Vitest via `loadEnv("test", process.cwd())` (`vitest.config.ts:29`), w
 
 | Variable                 | Read where                                   | Effect                                                                                   |
 | ------------------------ | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `VITE_FORK_RPC_URL`      | `testWithRpc.ts:25`                          | If set, Anvil boots as a fork of this URL and `setupContracts` is **skipped**.           |
+| `VITE_FORK_RPC_URL`      | `testWithRpc.ts`                             | If set, Anvil boots as a fork of this URL and `setupContracts` is **skipped**.           |
 | `CI`                     | `vitest.config.ts:10`                        | Switches coverage reporter to `lcov` only.                                               |
 
 Other `VITE_*` vars (`VITE_ANVIL_BLOCK_NUMBER`, `VITE_ANVIL_BLOCK_TIME`, `VITE_NETWORK_TRANSPORT_MODE`, `VITE_BATCH_MULTICALL`, `VITE_ANVIL_FORK_URL`) appear in `verify.yml` but are only consumed by the disabled sharded job. They have no effect in the active `testWithRpc` fixture.
@@ -89,14 +89,15 @@ bun run test
 
 Behaviour changes:
 
-- Anvil is started with `forkUrl` set (`testWithRpc.ts:29`).
-- `setupContracts(anvilRpc)` is **not called** (`testWithRpc.ts:70`). The fork is expected to already contain EntryPoints + factories at their canonical deterministic addresses.
+- Anvil is started with `forkUrl` set in the shared rig.
+- `setupContracts(anvilRpc)` is **not called**. The fork is expected to already contain EntryPoints + factories at their canonical deterministic addresses.
 - Alto and the mock paymaster still start normally.
+- Paymaster deposits are still topped up (1000 ETH per EntryPoint).
 
 Caveats:
 
-- The fork is recreated per-test, so every test issues a fresh set of forked reads. Use a reliable/high-rate archive node or expect throttling.
-- If the forked chain's `chainId ≠ foundry.id (31337)`, `eth_chainId` will differ and viem clients configured with `chain: foundry` may misbehave. The test fixture explicitly sets `chainId: foundry.id` on the Anvil instance to paper over this for most cases.
+- The fork is created once per worker and shared across all tests in that worker. Tests share the forked chain state.
+- If the forked chain's `chainId ≠ foundry.id (31337)`, `eth_chainId` will differ and viem clients configured with `chain: foundry` may misbehave. The shared rig explicitly sets `chainId: foundry.id` on the Anvil instance to paper over this for most cases.
 - Smart account addresses computed counterfactually from factory addresses only match reality if the factories on the forked chain match the deterministic-deployer addresses used locally.
 
 ## Running subsets
@@ -123,11 +124,11 @@ Vitest's interactive keyboard controls in watch mode (`p` for file filter, `t` f
 
 ### "Server listening at" never appears → `hookTimeout` error
 
-Alto is failing to start silently. The `prool` wrapper listens for the literal string `"Server listening at"` on Alto's stdout (`mock-aa-infra/alto/instance.ts:278`) and does not inspect stderr. If Alto crashes on boot, the hook hangs until the 45s `hookTimeout` fires.
+Alto is failing to start silently. The `prool` wrapper listens for the literal string `"Server listening at"` on Alto's stdout (`mock-aa-infra/alto/instance.ts:278`) and does not inspect stderr. If Alto crashes on boot, the hook hangs until the 45s `hookTimeout` fires. This only affects the **first test** in a worker (subsequent tests reuse the already-running Alto).
 
 **Fix:**
 
-1. Uncomment the stderr hooks in `testWithRpc.ts:55–60` temporarily:
+1. Uncomment the stderr hooks temporarily:
    ```ts
    altoInstance.on("stderr", (data) => console.error(data.toString()))
    altoInstance.on("stdout", (data) => console.log(data.toString()))
@@ -144,21 +145,42 @@ Common causes:
 - The creation-call bytes were regenerated with a different salt, changing the deterministic address.
 - A dependent contract's batch is missing from `verifyDeployed`'s manifest.
 
-### Tests hang on teardown
+### "AA31 paymaster deposit too low"
 
-If `.stop()` on one of the instances hangs, the per-test hook times out. Usually caused by a zombie child process from a prior run. Find and kill it:
+This error means the paymaster doesn't have enough ETH deposited in the EntryPoint to cover the gas costs of a user operation.
+
+Common causes:
+- **Base fee inflation:** If the base fee reset is missing or broken, gas costs spiral after many mined blocks. Check that `testClient.setNextBlockBaseFeePerGas` runs before each test in the `testWithRpc` fixture.
+- **Insufficient deposit top-up:** The shared rig deposits 1000 ETH per EntryPoint at startup. If you're adding many new tests that consume paymaster deposits, you may need to increase this amount in `getSharedRig()`.
+- **Wrong paymaster address:** The deposit must go to the correct paymaster contract address (computed via `getSingletonPaymaster0{6,7,8}Address` from `packages/mock-paymaster/constants.ts`).
+
+### Cross-test state contamination
+
+If a test fails with unexpected on-chain state (e.g. "AA13 initCode failed" because an account is already deployed, or EIP-7702 delegation errors):
+
+- **Check for hardcoded private keys.** Tests must use `generatePrivateKey()` to create unique keys. A hardcoded key shared across tests means the same counterfactual address is reused, and one test's deployment/delegation persists into the next.
+- **Check key placement.** The `generatePrivateKey()` call should be inside the `describe.each` callback (per account type), not at module level (shared across all account types). EIP-7702 delegation from one account type (e.g. Kernel 0.3.3+EIP-7702) can contaminate another (e.g. Nexus) if they share the same owner key.
+
+### Tests hang or timeout on first test only
+
+The first test in each worker pays the cold-start cost of `getSharedRig()` (anvil boot + contract deployment + alto + paymaster + deposit top-up). This typically takes 10–20s. If it exceeds the 45s `hookTimeout`, the test fails.
+
+**Fix:** Check if `setupContracts` is stalling (usually a contract deployment failure). See the "Server listening at" troubleshooting above.
+
+### Orphaned processes after test run
+
+After a run, check for orphaned processes:
 
 ```bash
 pgrep -f "alto"   # alto Node process
 pgrep -f "anvil"  # anvil
-pgrep -f "node.*mock-paymaster"  # mock paymaster
 ```
 
-Then `kill -9 <pid>` and retry.
+The shared rig registers a `process.on("beforeExit")` handler to stop all instances. If the worker is killed abruptly (e.g. `kill -9`), this handler may not run. Kill orphaned processes manually with `kill -9 <pid>`.
 
 ### `EADDRINUSE: address already in use`
 
-`get-port` normally prevents this, but if a background process (e.g. a local dev server) grabs the same port between the `getPort()` call and the service actually listening, you'll see this. Re-run; the probability of collision on the retry is negligible.
+`get-port` normally prevents this, but if a background process (e.g. a local dev server) grabs the same port between the `getPort()` call and the service actually listening, you'll see this. Re-run; the probability of collision on the retry is negligible. With the shared-rig model, ports are allocated once per worker (not per test), so collisions are even rarer.
 
 ### Fork mode: tests that used to pass now fail
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -4,37 +4,55 @@ This directory documents how the `permissionless.js` test suite works end-to-end
 
 ## The short version
 
-Every test in this repository runs against **its own dedicated ERC-4337 stack**:
+Tests in this repository run against a **shared ERC-4337 stack per Vitest worker**:
 
-1. A fresh **Anvil** node (L1 EVM).
-2. A fresh **Alto** bundler (`@pimlico/alto`) pointed at that Anvil.
-3. A fresh **mock paymaster** (Fastify server) pointed at both Anvil and Alto.
+1. One **Anvil** node (L1 EVM) per worker.
+2. One **Alto** bundler (`@pimlico/alto`) pointed at that Anvil.
+3. One **mock paymaster** (Fastify server) pointed at both Anvil and Alto.
 
-These three processes are spawned on dynamically-allocated ports, all core smart-account contracts (EntryPoints v0.6/v0.7/v0.8, SimpleAccount, Safe, Kernel, LightAccount, Biconomy, Trust, Nexus, Etherspot, Thirdweb, ERC-7579 modules, …) are deployed via a deterministic deployer, and then the test body receives `{ anvilRpc, altoRpc, paymasterRpc }` to wire up viem clients. After the test returns, all three processes are stopped and their ports released.
+These three processes are spawned **once per worker** on dynamically-allocated ports when the first test in that worker runs. All core smart-account contracts (EntryPoints v0.6/v0.7/v0.8, SimpleAccount, Safe, Kernel, LightAccount, Biconomy, Trust, Nexus, Etherspot, Thirdweb, ERC-7579 modules, …) are deployed via a deterministic deployer, and paymaster deposits are topped up with 1000 ETH per EntryPoint. Each test receives `{ anvilRpc, altoRpc, paymasterRpc }` to wire up viem clients.
 
-This guarantees complete state isolation: no test can see state produced by another, and tests within the same file run serially but files run in parallel.
+Between tests, the shared infrastructure is reset:
+- Alto's mempool and reputation are cleared via `debug_bundler_clearState`.
+- The base fee is reset to 1 gwei to prevent EIP-1559 inflation from accumulated mined blocks.
 
-## Per-test lifecycle
+Each test uses a **fresh private key** (`generatePrivateKey()`) so counterfactual smart-account addresses differ per test, providing account-level isolation without restarting processes.
+
+When the worker exits, all three processes are stopped.
+
+## Per-worker lifecycle
 
 ```
-┌─────────────────────────── one test ──────────────────────────────┐
-│                                                                   │
-│  1. allocate 3 ports via get-port (alto, paymaster, anvil)        │
-│  2. start anvil on anvilPort (chainId=foundry, hardfork=Prague)   │
-│  3. setupContracts(anvilRpc)                                      │
-│       └─ ~80 txns to the deterministic deployer +                 │
-│          a few setCode / impersonateAccount calls                 │
-│  4. start alto on altoPort (entrypoints: [0.6, 0.7, 0.8])         │
-│  5. start mock-paymaster on paymasterPort                         │
-│                                                                   │
-│  6. ── test body runs ──                                          │
-│     receives: { anvilRpc, altoRpc, paymasterRpc }                 │
-│     builds: public client, wallet client, bundler client,         │
-│             pimlico client, smart account(s), etc.                │
-│                                                                   │
-│  7. stop all 3 instances (Promise.all)                            │
-│  8. release ports                                                 │
-└───────────────────────────────────────────────────────────────────┘
+┌──────────────── worker startup (once) ────────────────────────┐
+│                                                                │
+│  1. allocate 3 ports via get-port (anvil, alto, paymaster)     │
+│  2. start anvil on anvilPort (chainId=foundry, hardfork=Prague)│
+│  3. setupContracts(anvilRpc)                                   │
+│       └─ ~80 txns to the deterministic deployer +              │
+│          a few setCode / impersonateAccount calls              │
+│  4. start alto on altoPort (entrypoints: [0.6, 0.7, 0.8],     │
+│       enableDebugEndpoints: true)                              │
+│  5. start mock-paymaster on paymasterPort                      │
+│  6. top up paymaster deposits (1000 ETH per EntryPoint)        │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+
+┌──────────────── per test ─────────────────────────────────────┐
+│                                                                │
+│  1. clear alto mempool + reputation (debug_bundler_clearState) │
+│  2. reset base fee to 1 gwei + mine a block                   │
+│  3. ── test body runs ──                                       │
+│     receives: { anvilRpc, altoRpc, paymasterRpc }              │
+│     builds: public client, wallet client, bundler client,      │
+│             pimlico client, smart account(s), etc.             │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+
+┌──────────────── worker shutdown ──────────────────────────────┐
+│                                                                │
+│  process.on("beforeExit") → stop alto, paymaster, anvil        │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
 ```
 
 ## What to read
@@ -44,7 +62,7 @@ Read these in order if you're new. Each document is self-contained; cross-links 
 | #   | Doc                                                   | What's in it                                                                          |
 | --- | ----------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | 01  | [01-architecture.md](./01-architecture.md)            | `bun run test` command chain, `vitest.config.ts`, file layout, test discovery.        |
-| 02  | [02-lifecycle.md](./02-lifecycle.md)                  | The `testWithRpc` fixture: ports, setup, teardown, state isolation guarantees.        |
+| 02  | [02-lifecycle.md](./02-lifecycle.md)                  | The `testWithRpc` fixture: shared rig, per-test reset, state isolation guarantees.    |
 | 03  | [03-infrastructure.md](./03-infrastructure.md)        | Anvil, Alto, and the mock paymaster — how each process is spawned and configured.     |
 | 04  | [04-contracts.md](./04-contracts.md)                  | `setupContracts`, the deterministic deployer, the full contract catalog, how to add a new one. |
 | 05  | [05-clients-accounts.md](./05-clients-accounts.md)    | Every viem/Pimlico/smart-account helper in `packages/permissionless-test/src/utils.ts`. |
@@ -67,7 +85,7 @@ Everything test-related lives in three packages:
 
 - `packages/permissionless/vitest.config.ts` — the Vitest config that `bun run test` points at.
 - `packages/permissionless-test/` — shared fixtures, client helpers, and the mock bundler infra. **Not published; test-only.**
-  - `src/testWithRpc.ts` — the `test.extend(...)` fixture that spins up the stack.
+  - `src/testWithRpc.ts` — the `test.extend(...)` fixture with shared per-worker rig, `createAutoBundleTransport`, and per-test reset logic.
   - `src/utils.ts` — every `get*Client`/`get*AccountClient` helper tests reach for.
   - `src/types.ts` — `AAParamType`.
   - `mock-aa-infra/alto/index.ts` — `setupContracts()` that deploys everything.

--- a/packages/permissionless-test/src/testWithRpc.ts
+++ b/packages/permissionless-test/src/testWithRpc.ts
@@ -1,6 +1,7 @@
 import { paymaster } from "@pimlico/mock-paymaster"
 import getPort from "get-port"
 import { anvil } from "prool/instances"
+import { custom, createTestClient, http } from "viem"
 import {
     entryPoint06Address,
     entryPoint07Address,
@@ -11,6 +12,183 @@ import { test } from "vitest"
 import { setupContracts } from "../mock-aa-infra/alto"
 import { alto } from "../mock-aa-infra/alto/instance"
 
+const anvilPrivateKey =
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+const forkUrl = (import.meta as any).env.VITE_FORK_RPC_URL as
+    | string
+    | undefined
+
+/**
+ * Creates a bundler transport that automatically calls
+ * debug_bundler_sendBundleNow + mines a block after every eth_sendUserOperation.
+ * This makes bundling deterministic and near-instant.
+ */
+function createAutoBundleTransport(altoRpc: string, anvilRpc: string) {
+    const baseTransport = http(altoRpc)
+
+    return custom({
+        async request({ method, params }) {
+            const transport = baseTransport({ chain: foundry })
+            const result = await transport.request({ method, params } as any)
+
+            // After a user op is submitted, immediately bundle + mine
+            if (method === "eth_sendUserOperation") {
+                await fetch(altoRpc, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        jsonrpc: "2.0",
+                        method: "debug_bundler_sendBundleNow",
+                        params: [],
+                        id: 1
+                    })
+                })
+                // Mine a block so the bundle tx is included
+                const testClient = createTestClient({
+                    mode: "anvil",
+                    chain: foundry,
+                    transport: http(anvilRpc)
+                })
+                await testClient.mine({ blocks: 1 })
+            }
+
+            return result
+        }
+    })
+}
+
+// Shared anvil + alto + paymaster per worker.
+// Each test uses a fresh smart account (unique private key), so on-chain state
+// from previous tests doesn't interfere. We just clear alto's mempool between tests.
+type SharedRig = {
+    anvilRpc: string
+    altoRpc: string
+    paymasterRpc: string
+    anvilInstance: Awaited<ReturnType<typeof anvil>>
+    altoInstance: Awaited<ReturnType<typeof alto>>
+    paymasterInstance: Awaited<ReturnType<typeof paymaster>>
+}
+
+let sharedRigPromise: Promise<SharedRig> | null = null
+
+async function getSharedRig(): Promise<SharedRig> {
+    if (sharedRigPromise) return sharedRigPromise
+    sharedRigPromise = (async () => {
+        const anvilPort = await getPort()
+        const altoPort = await getPort({ exclude: [anvilPort] })
+        const paymasterPort = await getPort({
+            exclude: [anvilPort, altoPort]
+        })
+        const anvilRpc = `http://localhost:${anvilPort}`
+        const altoRpc = `http://localhost:${altoPort}`
+        const paymasterRpc = `http://localhost:${paymasterPort}`
+
+        const anvilInstance = forkUrl
+            ? anvil({
+                  chainId: foundry.id,
+                  port: anvilPort,
+                  hardfork: "Prague",
+                  forkUrl
+              })
+            : anvil({
+                  chainId: foundry.id,
+                  hardfork: "Prague",
+                  port: anvilPort
+              })
+
+        await anvilInstance.start()
+
+        if (!forkUrl) {
+            await setupContracts(anvilRpc)
+        }
+
+        const altoInstance = alto({
+            entrypoints: [
+                entryPoint06Address,
+                entryPoint07Address,
+                entryPoint08Address
+            ],
+            rpcUrl: anvilRpc,
+            executorPrivateKeys: [anvilPrivateKey],
+            safeMode: false,
+            port: altoPort,
+            utilityPrivateKey: anvilPrivateKey,
+            enableDebugEndpoints: true
+        })
+
+        await altoInstance.start()
+
+        const paymasterInstance = paymaster({
+            anvilRpc,
+            port: paymasterPort,
+            altoRpc
+        })
+
+        await paymasterInstance.start()
+
+        return {
+            anvilRpc,
+            altoRpc,
+            paymasterRpc,
+            anvilInstance,
+            altoInstance,
+            paymasterInstance
+        }
+    })()
+    return sharedRigPromise
+}
+
+async function clearAltoState(altoRpc: string): Promise<void> {
+    await fetch(altoRpc, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            jsonrpc: "2.0",
+            method: "debug_bundler_clearState",
+            params: [],
+            id: 1
+        })
+    })
+}
+
+// Clean up shared rig when the worker process exits
+process.on("beforeExit", async () => {
+    if (!sharedRigPromise) return
+    const rig = await sharedRigPromise
+    await Promise.all([
+        rig.altoInstance.stop(),
+        rig.paymasterInstance.stop(),
+        rig.anvilInstance.stop()
+    ])
+    sharedRigPromise = null
+})
+
+export const testWithRpc = test.extend<{
+    rpc: {
+        anvilRpc: string
+        altoRpc: string
+        paymasterRpc: string
+    }
+}>({
+    // biome-ignore lint/correctness/noEmptyPattern: Needed in vitest :/
+    rpc: async ({}, use) => {
+        const rig = await getSharedRig()
+
+        // Clear alto's mempool + reputation between tests
+        await clearAltoState(rig.altoRpc)
+
+        await use({
+            anvilRpc: rig.anvilRpc,
+            altoRpc: rig.altoRpc,
+            paymasterRpc: rig.paymasterRpc
+        })
+    }
+})
+
+export { createAutoBundleTransport }
+
+// Keep getInstances export for backwards compatibility (standalone trio, used in docs references)
 export const getInstances = async ({
     anvilPort,
     altoPort,
@@ -18,13 +196,6 @@ export const getInstances = async ({
 }: { anvilPort: number; altoPort: number; paymasterPort: number }) => {
     const anvilRpc = `http://localhost:${anvilPort}`
     const altoRpc = `http://localhost:${altoPort}`
-
-    const anvilPrivateKey =
-        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-
-    const forkUrl = (import.meta as any).env.VITE_FORK_RPC_URL as
-        | string
-        | undefined
 
     const anvilInstance = forkUrl
         ? anvil({
@@ -52,13 +223,6 @@ export const getInstances = async ({
         utilityPrivateKey: anvilPrivateKey
     })
 
-    // altoInstance.on("stderr", (data) => {
-    //     console.error(data.toString())
-    // })
-    // altoInstance.on("stdout", (data) => {
-    //     console.log(data.toString())
-    // })
-
     const paymasterInstance = paymaster({
         anvilRpc,
         port: paymasterPort,
@@ -76,53 +240,3 @@ export const getInstances = async ({
 
     return [anvilInstance, altoInstance, paymasterInstance]
 }
-
-let ports: number[] = []
-
-export const testWithRpc = test.extend<{
-    rpc: {
-        anvilRpc: string
-        altoRpc: string
-        paymasterRpc: string
-    }
-}>({
-    // biome-ignore lint/correctness/noEmptyPattern: Needed in vitest :/
-    rpc: async ({}, use) => {
-        const altoPort = await getPort({
-            exclude: ports
-        })
-        ports.push(altoPort)
-        const paymasterPort = await getPort({
-            exclude: ports
-        })
-        ports.push(paymasterPort)
-        const anvilPort = await getPort({
-            exclude: ports
-        })
-        ports.push(anvilPort)
-
-        const anvilRpc = `http://localhost:${anvilPort}`
-        const altoRpc = `http://localhost:${altoPort}`
-        const paymasterRpc = `http://localhost:${paymasterPort}`
-
-        const instances = await getInstances({
-            anvilPort,
-            altoPort,
-            paymasterPort
-        })
-
-        await use({
-            anvilRpc,
-            altoRpc,
-            paymasterRpc
-        })
-
-        await Promise.all(instances.map((instance) => instance.stop()))
-        ports = ports.filter(
-            (port) =>
-                port !== altoPort ||
-                port !== anvilPort ||
-                port !== paymasterPort
-        )
-    }
-})

--- a/packages/permissionless-test/src/testWithRpc.ts
+++ b/packages/permissionless-test/src/testWithRpc.ts
@@ -1,23 +1,33 @@
 import { paymaster } from "@pimlico/mock-paymaster"
 import getPort from "get-port"
 import { anvil } from "prool/instances"
-import { custom, createTestClient, http } from "viem"
+import {
+    http,
+    createTestClient,
+    createWalletClient,
+    custom,
+    parseEther
+} from "viem"
 import {
     entryPoint06Address,
     entryPoint07Address,
     entryPoint08Address
 } from "viem/account-abstraction"
+import { privateKeyToAccount } from "viem/accounts"
 import { foundry } from "viem/chains"
 import { test } from "vitest"
 import { setupContracts } from "../mock-aa-infra/alto"
 import { alto } from "../mock-aa-infra/alto/instance"
+import {
+    getSingletonPaymaster06Address,
+    getSingletonPaymaster07Address,
+    getSingletonPaymaster08Address
+} from "../../mock-paymaster/constants"
 
 const anvilPrivateKey =
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
-const forkUrl = (import.meta as any).env.VITE_FORK_RPC_URL as
-    | string
-    | undefined
+const forkUrl = (import.meta as any).env.VITE_FORK_RPC_URL as string | undefined
 
 /**
  * Creates a bundler transport that automatically calls
@@ -127,6 +137,51 @@ async function getSharedRig(): Promise<SharedRig> {
 
         await paymasterInstance.start()
 
+        // Top up paymaster deposits so they don't run out across many tests
+        const paymasterSignerAddress = privateKeyToAccount(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ).address
+        const walletClient = createWalletClient({
+            chain: foundry,
+            account: privateKeyToAccount(anvilPrivateKey),
+            transport: http(anvilRpc)
+        })
+        const depositToAbi = [
+            {
+                name: "depositTo",
+                type: "function",
+                inputs: [{ type: "address", name: "account" }],
+                outputs: [],
+                stateMutability: "payable"
+            }
+        ] as const
+        const paymasterAddresses = [
+            {
+                entryPoint: entryPoint06Address,
+                paymaster:
+                    getSingletonPaymaster06Address(paymasterSignerAddress)
+            },
+            {
+                entryPoint: entryPoint07Address,
+                paymaster:
+                    getSingletonPaymaster07Address(paymasterSignerAddress)
+            },
+            {
+                entryPoint: entryPoint08Address,
+                paymaster:
+                    getSingletonPaymaster08Address(paymasterSignerAddress)
+            }
+        ]
+        for (const { entryPoint, paymaster: pm } of paymasterAddresses) {
+            await walletClient.writeContract({
+                address: entryPoint,
+                abi: depositToAbi,
+                functionName: "depositTo",
+                args: [pm],
+                value: parseEther("1000")
+            })
+        }
+
         return {
             anvilRpc,
             altoRpc,
@@ -177,6 +232,19 @@ export const testWithRpc = test.extend<{
 
         // Clear alto's mempool + reputation between tests
         await clearAltoState(rig.altoRpc)
+
+        // Reset base fee to prevent inflation from accumulated mined blocks.
+        // Without this, base fee grows with each non-empty block across tests,
+        // causing "AA31 paymaster deposit too low" errors.
+        const testClient = createTestClient({
+            mode: "anvil",
+            chain: foundry,
+            transport: http(rig.anvilRpc)
+        })
+        await testClient.setNextBlockBaseFeePerGas({
+            baseFeePerGas: 1000000000n
+        })
+        await testClient.mine({ blocks: 1 })
 
         await use({
             anvilRpc: rig.anvilRpc,

--- a/packages/permissionless-test/src/testWithRpc.ts
+++ b/packages/permissionless-test/src/testWithRpc.ts
@@ -16,13 +16,13 @@ import {
 import { privateKeyToAccount } from "viem/accounts"
 import { foundry } from "viem/chains"
 import { test } from "vitest"
-import { setupContracts } from "../mock-aa-infra/alto"
-import { alto } from "../mock-aa-infra/alto/instance"
 import {
     getSingletonPaymaster06Address,
     getSingletonPaymaster07Address,
     getSingletonPaymaster08Address
 } from "../../mock-paymaster/constants"
+import { setupContracts } from "../mock-aa-infra/alto"
+import { alto } from "../mock-aa-infra/alto/instance"
 
 const anvilPrivateKey =
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -158,18 +158,21 @@ async function getSharedRig(): Promise<SharedRig> {
         const paymasterAddresses = [
             {
                 entryPoint: entryPoint06Address,
-                paymaster:
-                    getSingletonPaymaster06Address(paymasterSignerAddress)
+                paymaster: getSingletonPaymaster06Address(
+                    paymasterSignerAddress
+                )
             },
             {
                 entryPoint: entryPoint07Address,
-                paymaster:
-                    getSingletonPaymaster07Address(paymasterSignerAddress)
+                paymaster: getSingletonPaymaster07Address(
+                    paymasterSignerAddress
+                )
             },
             {
                 entryPoint: entryPoint08Address,
-                paymaster:
-                    getSingletonPaymaster08Address(paymasterSignerAddress)
+                paymaster: getSingletonPaymaster08Address(
+                    paymasterSignerAddress
+                )
             }
         ]
         for (const { entryPoint, paymaster: pm } of paymasterAddresses) {

--- a/packages/permissionless-test/src/utils.ts
+++ b/packages/permissionless-test/src/utils.ts
@@ -8,7 +8,6 @@ import {
     createPublicClient,
     createWalletClient
 } from "viem"
-import { createAutoBundleTransport } from "./testWithRpc"
 import {
     type EntryPointVersion,
     type SmartAccount,
@@ -55,6 +54,7 @@ import {
     createSmartAccountClient
 } from "../../permissionless/clients/createSmartAccountClient"
 import { createPimlicoClient } from "../../permissionless/clients/pimlico"
+import { createAutoBundleTransport } from "./testWithRpc"
 import type { AAParamType } from "./types"
 
 export const PAYMASTER_RPC = "http://localhost:3000"

--- a/packages/permissionless-test/src/utils.ts
+++ b/packages/permissionless-test/src/utils.ts
@@ -8,6 +8,7 @@ import {
     createPublicClient,
     createWalletClient
 } from "viem"
+import { createAutoBundleTransport } from "./testWithRpc"
 import {
     type EntryPointVersion,
     type SmartAccount,
@@ -159,7 +160,8 @@ export const getBundlerClient = <account extends SmartAccount | undefined>({
         client: getPublicClient(anvilRpc),
         account,
         paymaster,
-        bundlerTransport: http(altoRpc),
+        pollingInterval: 100,
+        bundlerTransport: createAutoBundleTransport(altoRpc, anvilRpc),
         userOperation: {
             estimateFeesPerGas: async () => {
                 return (await pimlicoBundler.getUserOperationGasPrice()).fast
@@ -192,7 +194,8 @@ export const getSmartAccountClient = <
         chain: foundry,
         account,
         paymaster,
-        bundlerTransport: http(altoRpc)
+        pollingInterval: 100,
+        bundlerTransport: createAutoBundleTransport(altoRpc, anvilRpc)
     })
 }
 
@@ -219,7 +222,8 @@ export const getPimlicoClient = <entryPointVersion extends EntryPointVersion>({
             address,
             version: entryPointVersion
         },
-        transport: http(altoRpc)
+        transport: http(altoRpc),
+        pollingInterval: 100
     })
 }
 

--- a/packages/permissionless/actions/erc7579/installModule.test.ts
+++ b/packages/permissionless/actions/erc7579/installModule.test.ts
@@ -104,14 +104,14 @@ describe.each(getCoreSmartAccounts())(
             }
         )
         testWithRpc.skipIf(!getErc7579SmartAccountClient)(
-            "installModule",
+            "installModule post deployment",
             async ({ rpc }) => {
                 if (!getErc7579SmartAccountClient) {
                     throw new Error("getErc7579SmartAccountClient not defined")
                 }
 
                 const privateKey =
-                    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
+                    "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"
 
                 const privateKeyAccount = privateKeyToAccount(privateKey)
 

--- a/packages/permissionless/actions/erc7579/installModule.test.ts
+++ b/packages/permissionless/actions/erc7579/installModule.test.ts
@@ -1,5 +1,5 @@
 import { encodeAbiParameters, encodePacked, isHash, zeroAddress } from "viem"
-import { privateKeyToAccount } from "viem/accounts"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { describe, expect } from "vitest"
 import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
 import {
@@ -19,8 +19,7 @@ describe.each(getCoreSmartAccounts())(
                     throw new Error("getErc7579SmartAccountClient not defined")
                 }
 
-                const privateKey =
-                    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
+                const privateKey = generatePrivateKey()
 
                 const privateKeyAccount = privateKeyToAccount(privateKey)
 
@@ -110,8 +109,7 @@ describe.each(getCoreSmartAccounts())(
                     throw new Error("getErc7579SmartAccountClient not defined")
                 }
 
-                const privateKey =
-                    "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"
+                const privateKey = generatePrivateKey()
 
                 const privateKeyAccount = privateKeyToAccount(privateKey)
 

--- a/packages/permissionless/actions/erc7579/installModules.test.ts
+++ b/packages/permissionless/actions/erc7579/installModules.test.ts
@@ -1,5 +1,5 @@
 import { encodeAbiParameters, encodePacked, isHash, zeroAddress } from "viem"
-import { privateKeyToAccount } from "viem/accounts"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { describe, expect } from "vitest"
 import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
 import {
@@ -19,8 +19,7 @@ describe.each(getCoreSmartAccounts())(
                     throw new Error("getErc7579SmartAccountClient not defined")
                 }
 
-                const privateKey =
-                    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
+                const privateKey = generatePrivateKey()
 
                 const privateKeyAccount = privateKeyToAccount(privateKey)
 
@@ -124,8 +123,7 @@ describe.each(getCoreSmartAccounts())(
                     throw new Error("getErc7579SmartAccountClient not defined")
                 }
 
-                const privateKey =
-                    "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"
+                const privateKey = generatePrivateKey()
 
                 const privateKeyAccount = privateKeyToAccount(privateKey)
 

--- a/packages/permissionless/actions/erc7579/installModules.test.ts
+++ b/packages/permissionless/actions/erc7579/installModules.test.ts
@@ -118,14 +118,14 @@ describe.each(getCoreSmartAccounts())(
             }
         )
         testWithRpc.skipIf(!getErc7579SmartAccountClient)(
-            "installModules",
+            "installModules post deployment",
             async ({ rpc }) => {
                 if (!getErc7579SmartAccountClient) {
                     throw new Error("getErc7579SmartAccountClient not defined")
                 }
 
                 const privateKey =
-                    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
+                    "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"
 
                 const privateKeyAccount = privateKeyToAccount(privateKey)
 

--- a/packages/permissionless/actions/erc7579/uninstallModule.test.ts
+++ b/packages/permissionless/actions/erc7579/uninstallModule.test.ts
@@ -1,5 +1,5 @@
 import { encodeAbiParameters, encodePacked, isHash, zeroAddress } from "viem"
-import { privateKeyToAccount } from "viem/accounts"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { describe, expect } from "vitest"
 import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
 import {
@@ -19,8 +19,7 @@ describe.each(getCoreSmartAccounts())(
                     throw new Error("getErc7579SmartAccountClient not defined")
                 }
 
-                const privateKey =
-                    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
+                const privateKey = generatePrivateKey()
 
                 const privateKeyAccount = privateKeyToAccount(privateKey)
 

--- a/packages/permissionless/actions/pimlico/getUserOperationStatus.test.ts
+++ b/packages/permissionless/actions/pimlico/getUserOperationStatus.test.ts
@@ -58,19 +58,19 @@ describe("getUserOperationStatus", () => {
         expect(receipt?.receipt.transactionHash).toBe(
             userOperationReceipt?.receipt.transactionHash
         )
-        let userOperationStatus = await getUserOperationStatus(
-            bundlerClient,
-            {
-                hash: opHash
-            }
-        )
+        let userOperationStatus = await getUserOperationStatus(bundlerClient, {
+            hash: opHash
+        })
         // Poll until alto's internal status catches up
-        for (let i = 0; i < 20 && userOperationStatus.status !== "included"; i++) {
-            await new Promise(r => setTimeout(r, 100))
-            userOperationStatus = await getUserOperationStatus(
-                bundlerClient,
-                { hash: opHash }
-            )
+        for (
+            let i = 0;
+            i < 20 && userOperationStatus.status !== "included";
+            i++
+        ) {
+            await new Promise((r) => setTimeout(r, 100))
+            userOperationStatus = await getUserOperationStatus(bundlerClient, {
+                hash: opHash
+            })
         }
         expect(userOperationStatus).not.toBeNull()
         expect(userOperationStatus).not.toBeUndefined()
@@ -129,19 +129,19 @@ describe("getUserOperationStatus", () => {
         expect(receipt?.receipt.transactionHash).toBe(
             userOperationReceipt?.receipt.transactionHash
         )
-        let userOperationStatus = await getUserOperationStatus(
-            bundlerClient,
-            {
-                hash: opHash
-            }
-        )
+        let userOperationStatus = await getUserOperationStatus(bundlerClient, {
+            hash: opHash
+        })
         // Poll until alto's internal status catches up
-        for (let i = 0; i < 20 && userOperationStatus.status !== "included"; i++) {
-            await new Promise(r => setTimeout(r, 100))
-            userOperationStatus = await getUserOperationStatus(
-                bundlerClient,
-                { hash: opHash }
-            )
+        for (
+            let i = 0;
+            i < 20 && userOperationStatus.status !== "included";
+            i++
+        ) {
+            await new Promise((r) => setTimeout(r, 100))
+            userOperationStatus = await getUserOperationStatus(bundlerClient, {
+                hash: opHash
+            })
         }
         expect(userOperationStatus).not.toBeNull()
         expect(userOperationStatus).not.toBeUndefined()
@@ -199,19 +199,19 @@ describe("getUserOperationStatus", () => {
         expect(receipt?.receipt.transactionHash).toBe(
             userOperationReceipt?.receipt.transactionHash
         )
-        let userOperationStatus = await getUserOperationStatus(
-            bundlerClient,
-            {
-                hash: opHash
-            }
-        )
+        let userOperationStatus = await getUserOperationStatus(bundlerClient, {
+            hash: opHash
+        })
         // Poll until alto's internal status catches up
-        for (let i = 0; i < 20 && userOperationStatus.status !== "included"; i++) {
-            await new Promise(r => setTimeout(r, 100))
-            userOperationStatus = await getUserOperationStatus(
-                bundlerClient,
-                { hash: opHash }
-            )
+        for (
+            let i = 0;
+            i < 20 && userOperationStatus.status !== "included";
+            i++
+        ) {
+            await new Promise((r) => setTimeout(r, 100))
+            userOperationStatus = await getUserOperationStatus(bundlerClient, {
+                hash: opHash
+            })
         }
         expect(userOperationStatus).not.toBeNull()
         expect(userOperationStatus).not.toBeUndefined()

--- a/packages/permissionless/actions/pimlico/getUserOperationStatus.test.ts
+++ b/packages/permissionless/actions/pimlico/getUserOperationStatus.test.ts
@@ -58,12 +58,20 @@ describe("getUserOperationStatus", () => {
         expect(receipt?.receipt.transactionHash).toBe(
             userOperationReceipt?.receipt.transactionHash
         )
-        const userOperationStatus = await getUserOperationStatus(
+        let userOperationStatus = await getUserOperationStatus(
             bundlerClient,
             {
                 hash: opHash
             }
         )
+        // Poll until alto's internal status catches up
+        for (let i = 0; i < 20 && userOperationStatus.status !== "included"; i++) {
+            await new Promise(r => setTimeout(r, 100))
+            userOperationStatus = await getUserOperationStatus(
+                bundlerClient,
+                { hash: opHash }
+            )
+        }
         expect(userOperationStatus).not.toBeNull()
         expect(userOperationStatus).not.toBeUndefined()
         expect(userOperationStatus.status).toBe("included")
@@ -121,12 +129,20 @@ describe("getUserOperationStatus", () => {
         expect(receipt?.receipt.transactionHash).toBe(
             userOperationReceipt?.receipt.transactionHash
         )
-        const userOperationStatus = await getUserOperationStatus(
+        let userOperationStatus = await getUserOperationStatus(
             bundlerClient,
             {
                 hash: opHash
             }
         )
+        // Poll until alto's internal status catches up
+        for (let i = 0; i < 20 && userOperationStatus.status !== "included"; i++) {
+            await new Promise(r => setTimeout(r, 100))
+            userOperationStatus = await getUserOperationStatus(
+                bundlerClient,
+                { hash: opHash }
+            )
+        }
         expect(userOperationStatus).not.toBeNull()
         expect(userOperationStatus).not.toBeUndefined()
         expect(userOperationStatus.status).toBe("included")
@@ -134,7 +150,7 @@ describe("getUserOperationStatus", () => {
             userOperationReceipt?.receipt.transactionHash
         )
     })
-    testWithRpc("getUserOperationStatus_V07", async ({ rpc }) => {
+    testWithRpc("getUserOperationStatus_V08", async ({ rpc }) => {
         const { altoRpc } = rpc
 
         const bundlerClient = getPimlicoClient({
@@ -183,12 +199,20 @@ describe("getUserOperationStatus", () => {
         expect(receipt?.receipt.transactionHash).toBe(
             userOperationReceipt?.receipt.transactionHash
         )
-        const userOperationStatus = await getUserOperationStatus(
+        let userOperationStatus = await getUserOperationStatus(
             bundlerClient,
             {
                 hash: opHash
             }
         )
+        // Poll until alto's internal status catches up
+        for (let i = 0; i < 20 && userOperationStatus.status !== "included"; i++) {
+            await new Promise(r => setTimeout(r, 100))
+            userOperationStatus = await getUserOperationStatus(
+                bundlerClient,
+                { hash: opHash }
+            )
+        }
         expect(userOperationStatus).not.toBeNull()
         expect(userOperationStatus).not.toBeUndefined()
         expect(userOperationStatus.status).toBe("included")

--- a/packages/permissionless/actions/smartAccount/getCallsStatus.test.ts
+++ b/packages/permissionless/actions/smartAccount/getCallsStatus.test.ts
@@ -1,5 +1,5 @@
 import { type Hex, zeroAddress } from "viem"
-import { privateKeyToAccount } from "viem/accounts"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { describe, expect } from "vitest"
 import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
 import {
@@ -8,9 +8,6 @@ import {
 } from "../../../permissionless-test/src/utils"
 import { getCallsStatus } from "./getCallsStatus"
 import { sendCalls } from "./sendCalls"
-
-const privateKey =
-    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
 
 describe.each(getCoreSmartAccounts())(
     "getCallsStatus $name",
@@ -21,6 +18,7 @@ describe.each(getCoreSmartAccounts())(
         supportsEntryPointV08,
         isEip7702Compliant
     }) => {
+        const privateKey = generatePrivateKey()
         testWithRpc.skipIf(!supportsEntryPointV06)(
             "getCallsStatus_v06",
             async ({ rpc }) => {

--- a/packages/permissionless/actions/smartAccount/sendCalls.test.ts
+++ b/packages/permissionless/actions/smartAccount/sendCalls.test.ts
@@ -1,6 +1,6 @@
 import { type Hex, zeroAddress } from "viem"
 import { waitForUserOperationReceipt } from "viem/account-abstraction"
-import { privateKeyToAccount } from "viem/accounts"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { describe, expect } from "vitest"
 import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
 import {
@@ -8,9 +8,6 @@ import {
     getPublicClient
 } from "../../../permissionless-test/src/utils"
 import { sendCalls } from "./sendCalls"
-
-const privateKey =
-    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
 
 describe.each(getCoreSmartAccounts())(
     "sendCalls $name",
@@ -21,6 +18,7 @@ describe.each(getCoreSmartAccounts())(
         supportsEntryPointV08,
         isEip7702Compliant
     }) => {
+        const privateKey = generatePrivateKey()
         testWithRpc.skipIf(!supportsEntryPointV06)(
             "sendCalls_v06",
             async ({ rpc }) => {

--- a/packages/permissionless/actions/smartAccount/sendTransaction.test.ts
+++ b/packages/permissionless/actions/smartAccount/sendTransaction.test.ts
@@ -1,5 +1,5 @@
 import { zeroAddress } from "viem"
-import { privateKeyToAccount } from "viem/accounts"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { describe, expect } from "vitest"
 import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
 import {
@@ -7,9 +7,6 @@ import {
     getPublicClient
 } from "../../../permissionless-test/src/utils"
 import { sendTransaction } from "./sendTransaction"
-
-const privateKey =
-    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
 
 describe.each(getCoreSmartAccounts())(
     "sendTransaction $name",
@@ -20,6 +17,7 @@ describe.each(getCoreSmartAccounts())(
         supportsEntryPointV08,
         isEip7702Compliant
     }) => {
+        const privateKey = generatePrivateKey()
         testWithRpc.skipIf(!supportsEntryPointV06)(
             "sendTransaction_v06",
             async ({ rpc }) => {

--- a/packages/permissionless/actions/smartAccount/signMessage.test.ts
+++ b/packages/permissionless/actions/smartAccount/signMessage.test.ts
@@ -1,5 +1,5 @@
 import { zeroAddress } from "viem"
-import { privateKeyToAccount } from "viem/accounts"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { describe, expect } from "vitest"
 import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
 import {
@@ -7,9 +7,6 @@ import {
     getPublicClient
 } from "../../../permissionless-test/src/utils"
 import { signMessage } from "./signMessage"
-
-const privateKey =
-    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
 
 describe.each(getCoreSmartAccounts())(
     "signMessage $name",
@@ -22,6 +19,7 @@ describe.each(getCoreSmartAccounts())(
         isEip7702Compliant,
         name
     }) => {
+        const privateKey = generatePrivateKey()
         testWithRpc.skipIf(isEip1271Compliant || !supportsEntryPointV06)(
             "not isEip1271Compliant_v06",
             async ({ rpc }) => {

--- a/packages/permissionless/actions/smartAccount/signTypedData.test.ts
+++ b/packages/permissionless/actions/smartAccount/signTypedData.test.ts
@@ -1,5 +1,5 @@
 import { getAddress, zeroAddress } from "viem"
-import { privateKeyToAccount } from "viem/accounts"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { describe, expect } from "vitest"
 import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
 import {
@@ -7,9 +7,6 @@ import {
     getPublicClient
 } from "../../../permissionless-test/src/utils"
 import { signTypedData } from "./signTypedData"
-
-const privateKey =
-    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
 
 const typedData = {
     domain: {
@@ -56,6 +53,7 @@ describe.each(getCoreSmartAccounts())(
         isEip7702Compliant,
         name
     }) => {
+        const privateKey = generatePrivateKey()
         testWithRpc.skipIf(isEip1271Compliant || !supportsEntryPointV06)(
             "not isEip1271Compliant_v06",
             async ({ rpc }) => {

--- a/packages/permissionless/experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.test.ts
+++ b/packages/permissionless/experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.test.ts
@@ -4,7 +4,7 @@ import {
     entryPoint07Address,
     entryPoint08Address
 } from "viem/account-abstraction"
-import { privateKeyToAccount } from "viem/accounts"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { foundry } from "viem/chains"
 import { describe, expect } from "vitest"
 import {
@@ -12,7 +12,10 @@ import {
     sudoMintTokens,
     tokenBalanceOf
 } from "../../../../mock-paymaster/helpers/erc20-utils"
-import { testWithRpc } from "../../../../permissionless-test/src/testWithRpc"
+import {
+    createAutoBundleTransport,
+    testWithRpc
+} from "../../../../permissionless-test/src/testWithRpc"
 import {
     getCoreSmartAccounts,
     getPublicClient
@@ -20,9 +23,6 @@ import {
 import { createSmartAccountClient } from "../../../clients/createSmartAccountClient"
 import { createPimlicoClient } from "../../../clients/pimlico"
 import { prepareUserOperationForErc20Paymaster } from "./prepareUserOperationForErc20Paymaster"
-
-const privateKey =
-    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
 
 describe.each(getCoreSmartAccounts())(
     "prepareUserOperationForErc20Paymaster $name",
@@ -34,6 +34,7 @@ describe.each(getCoreSmartAccounts())(
         isEip7702Compliant,
         name
     }) => {
+        const privateKey = generatePrivateKey()
         testWithRpc.skipIf(!supportsEntryPointV06 || name === "Kernel 0.2.1")(
             "prepareUserOperationForErc20Paymaster_v06",
             async ({ rpc }) => {
@@ -69,19 +70,29 @@ describe.each(getCoreSmartAccounts())(
                         prepareUserOperation:
                             prepareUserOperationForErc20Paymaster(pimlicoClient)
                     },
-                    bundlerTransport: http(rpc.altoRpc)
+                    bundlerTransport: createAutoBundleTransport(
+                        rpc.altoRpc,
+                        rpc.anvilRpc
+                    )
                 })
 
-                const INITIAL_TOKEN_BALANCE = parseEther("100")
                 const INTIAL_ETH_BALANCE = await publicClient.getBalance({
                     address: smartAccountClient.account.address
                 })
 
-                sudoMintTokens({
-                    amount: INITIAL_TOKEN_BALANCE,
+                const PRE_MINT_TOKEN_BALANCE = await tokenBalanceOf(
+                    smartAccountClient.account.address,
+                    rpc.anvilRpc
+                )
+
+                await sudoMintTokens({
+                    amount: parseEther("100"),
                     to: smartAccountClient.account.address,
                     anvilRpc
                 })
+
+                const INITIAL_TOKEN_BALANCE =
+                    PRE_MINT_TOKEN_BALANCE + parseEther("100")
 
                 const opHash = await smartAccountClient.sendUserOperation({
                     calls: [
@@ -155,19 +166,29 @@ describe.each(getCoreSmartAccounts())(
                         prepareUserOperation:
                             prepareUserOperationForErc20Paymaster(pimlicoClient)
                     },
-                    bundlerTransport: http(rpc.altoRpc)
+                    bundlerTransport: createAutoBundleTransport(
+                        rpc.altoRpc,
+                        rpc.anvilRpc
+                    )
                 })
 
-                const INITIAL_TOKEN_BALANCE = parseEther("100")
                 const INTIAL_ETH_BALANCE = await publicClient.getBalance({
                     address: smartAccountClient.account.address
                 })
 
-                sudoMintTokens({
-                    amount: INITIAL_TOKEN_BALANCE,
+                const PRE_MINT_TOKEN_BALANCE = await tokenBalanceOf(
+                    smartAccountClient.account.address,
+                    rpc.anvilRpc
+                )
+
+                await sudoMintTokens({
+                    amount: parseEther("100"),
                     to: smartAccountClient.account.address,
                     anvilRpc
                 })
+
+                const INITIAL_TOKEN_BALANCE =
+                    PRE_MINT_TOKEN_BALANCE + parseEther("100")
 
                 const authorization = isEip7702Compliant
                     ? await privateKeyAccount.signAuthorization({
@@ -253,19 +274,29 @@ describe.each(getCoreSmartAccounts())(
                         prepareUserOperation:
                             prepareUserOperationForErc20Paymaster(pimlicoClient)
                     },
-                    bundlerTransport: http(rpc.altoRpc)
+                    bundlerTransport: createAutoBundleTransport(
+                        rpc.altoRpc,
+                        rpc.anvilRpc
+                    )
                 })
 
-                const INITIAL_TOKEN_BALANCE = parseEther("100")
                 const INTIAL_ETH_BALANCE = await publicClient.getBalance({
                     address: smartAccountClient.account.address
                 })
 
-                sudoMintTokens({
-                    amount: INITIAL_TOKEN_BALANCE,
+                const PRE_MINT_TOKEN_BALANCE = await tokenBalanceOf(
+                    smartAccountClient.account.address,
+                    rpc.anvilRpc
+                )
+
+                await sudoMintTokens({
+                    amount: parseEther("100"),
                     to: smartAccountClient.account.address,
                     anvilRpc
                 })
+
+                const INITIAL_TOKEN_BALANCE =
+                    PRE_MINT_TOKEN_BALANCE + parseEther("100")
 
                 const authorization = isEip7702Compliant
                     ? await privateKeyAccount.signAuthorization({
@@ -356,19 +387,29 @@ describe.each(getCoreSmartAccounts())(
                                 }
                             )
                     },
-                    bundlerTransport: http(rpc.altoRpc)
+                    bundlerTransport: createAutoBundleTransport(
+                        rpc.altoRpc,
+                        rpc.anvilRpc
+                    )
                 })
 
-                const INITIAL_TOKEN_BALANCE = parseEther("100")
                 const INTIAL_ETH_BALANCE = await publicClient.getBalance({
                     address: smartAccountClient.account.address
                 })
 
-                sudoMintTokens({
-                    amount: INITIAL_TOKEN_BALANCE,
+                const PRE_MINT_TOKEN_BALANCE = await tokenBalanceOf(
+                    smartAccountClient.account.address,
+                    rpc.anvilRpc
+                )
+
+                await sudoMintTokens({
+                    amount: parseEther("100"),
                     to: smartAccountClient.account.address,
                     anvilRpc
                 })
+
+                const INITIAL_TOKEN_BALANCE =
+                    PRE_MINT_TOKEN_BALANCE + parseEther("100")
 
                 const authorization = isEip7702Compliant
                     ? await privateKeyAccount.signAuthorization({
@@ -459,19 +500,29 @@ describe.each(getCoreSmartAccounts())(
                                 }
                             )
                     },
-                    bundlerTransport: http(rpc.altoRpc)
+                    bundlerTransport: createAutoBundleTransport(
+                        rpc.altoRpc,
+                        rpc.anvilRpc
+                    )
                 })
 
-                const INITIAL_TOKEN_BALANCE = parseEther("100")
                 const INTIAL_ETH_BALANCE = await publicClient.getBalance({
                     address: smartAccountClient.account.address
                 })
 
-                sudoMintTokens({
-                    amount: INITIAL_TOKEN_BALANCE,
+                const PRE_MINT_TOKEN_BALANCE = await tokenBalanceOf(
+                    smartAccountClient.account.address,
+                    rpc.anvilRpc
+                )
+
+                await sudoMintTokens({
+                    amount: parseEther("100"),
                     to: smartAccountClient.account.address,
                     anvilRpc
                 })
+
+                const INITIAL_TOKEN_BALANCE =
+                    PRE_MINT_TOKEN_BALANCE + parseEther("100")
 
                 const authorization = isEip7702Compliant
                     ? await privateKeyAccount.signAuthorization({


### PR DESCRIPTION
## Changes

- **Share infrastructure per worker**: Move anvil, alto, and paymaster infrastructure to be shared per worker instead of per test, reducing overhead and improving test speed by ~8x
- **Unique private keys per account type**: Use distinct private keys for each account type to prevent cross-test state contamination
- **Fix ERC20 paymaster test**: Update paymaster test to work correctly with shared infrastructure
- **Update dependencies**: Upgrade viem from 2.28.1 to 2.44.4 and ox from 0.8.0 to 0.11.3
- **Code formatting**: Apply biome formatting across test files

## Performance Impact

Test suite execution speed improved by approximately 8x through infrastructure sharing while maintaining test isolation.