### PR TITLE
fix: simplify smart account client return type

### DIFF
--- a/packages/permissionless/clients/createSmartAccountClient.ts
+++ b/packages/permissionless/clients/createSmartAccountClient.ts
@@ -119,21 +119,9 @@ export type SmartAccountClientConfig<
         | undefined
 }
 
-export function createSmartAccountClient<
-    transport extends Transport,
-    chain extends Chain | undefined = undefined,
-    account extends SmartAccount | undefined = undefined,
-    client extends Client | undefined = undefined,
-    rpcSchema extends RpcSchema | undefined = undefined
->(
-    parameters: SmartAccountClientConfig<
-        transport,
-        chain,
-        account,
-        client,
-        rpcSchema
-    >
-): SmartAccountClient<transport, chain, account, client, rpcSchema>
+export function createSmartAccountClient(
+    parameters: SmartAccountClientConfig
+): SmartAccountClient
 
 export function createSmartAccountClient(
     parameters: SmartAccountClientConfig


### PR DESCRIPTION
## Summary

- Widen the public `createSmartAccountClient` overload to return the exported `SmartAccountClient` alias directly.
- Avoid exposing the full nested `transport/chain/account/client/rpcSchema` instantiation at the call site, which is the expensive assignability path described in #500.

Closes #500.

## Verification

- `bun install --frozen-lockfile`
- `git diff --check`
- `bun run build:permissionless:types` was started but did not finish within a 120s local timeout on this machine.
- `bun run lint` currently fails on pre-existing repository warnings/errors unrelated to this change (for example existing `noExplicitAny` diagnostics in `packages/mock-paymaster`, `packages/wagmi`, tests, and an existing `Client<any, ...>` type in this file).
