### PR TITLE
Preserve hex bytes when appending dataSuffix

### DIFF
--- a/packages/permissionless/actions/smartAccount/writeContract.test.ts
+++ b/packages/permissionless/actions/smartAccount/writeContract.test.ts
@@ -1,0 +1,29 @@
+import type { Client, Hex, Transport } from "viem"
+import { describe, expect, test, vi } from "vitest"
+
+import { writeContract } from "./writeContract"
+
+vi.mock("viem", () => ({
+    encodeFunctionData: () => "0x1000"
+}))
+
+vi.mock("viem/utils", () => ({
+    getAction: () => async (parameters: { data: Hex }) => parameters.data
+}))
+
+describe("writeContract", () => {
+    test("removes only the dataSuffix hex prefix", async () => {
+        const data = await writeContract(
+            {} as Client<Transport, undefined, undefined>,
+            {
+                abi: [],
+                address: "0x0000000000000000000000000000000000000000",
+                functionName: "setValue",
+                args: [0x10n],
+                dataSuffix: "0x10"
+            }
+        )
+
+        expect(data).toBe("0x100010")
+    })
+})

--- a/packages/permissionless/actions/smartAccount/writeContract.ts
+++ b/packages/permissionless/actions/smartAccount/writeContract.ts
@@ -58,7 +58,7 @@ export async function writeContract<
         sendTransaction<TAccount, undefined, undefined>,
         "sendTransaction"
     )({
-        data: `${data}${dataSuffix ? dataSuffix.replace("0x", "") : ""}`,
+        data: `${data}${dataSuffix ? dataSuffix.replace(/^0x/, "") : ""}`,
         to: address,
         ...request
     } as unknown as SendTransactionParameters<


### PR DESCRIPTION
Fixes `writeContract` data suffix handling so only a leading `0x` prefix is removed before appending.

The previous `dataSuffix.replace("0x", "")` removes the first `0x` anywhere in the suffix. For normal hex values that is usually the prefix, but anchoring the replacement avoids mutating any later bytes if a malformed or future caller-provided suffix contains `0x` after the prefix position.

Also adds a focused unit test for the appended calldata path.

Checked with:
- `git diff --check`

I could not run the project test/build locally because this repo is Bun-based and Bun is not installed in this environment.