### PR TITLE
Expose utils for generating ERC-1271 signatures

### DIFF
--- a/packages/permissionless/accounts/kernel/utils/index.ts
+++ b/packages/permissionless/accounts/kernel/utils/index.ts
@@ -1,0 +1,7 @@
+export {
+  wrapMessageHash,
+  type WrapMessageHashParams,
+} from "./wrapMessageHash.js";
+export { signMessage } from "./signMessage.js";
+export { signTypedData } from "./signTypedData.js";
+export { isKernelV2 } from "./isKernelV2.js";

--- a/packages/permissionless/accounts/kernel/utils/index.ts
+++ b/packages/permissionless/accounts/kernel/utils/index.ts
@@ -1,7 +1,7 @@
 export {
-  wrapMessageHash,
-  type WrapMessageHashParams,
-} from "./wrapMessageHash.js";
-export { signMessage } from "./signMessage.js";
-export { signTypedData } from "./signTypedData.js";
-export { isKernelV2 } from "./isKernelV2.js";
+    wrapMessageHash,
+    type WrapMessageHashParams
+} from "./wrapMessageHash.js"
+export { signMessage } from "./signMessage.js"
+export { signTypedData } from "./signTypedData.js"
+export { isKernelV2 } from "./isKernelV2.js"

--- a/packages/permissionless/package.json
+++ b/packages/permissionless/package.json
@@ -1,102 +1,113 @@
 {
-    "name": "permissionless",
-    "version": "0.3.5",
-    "author": "Pimlico",
-    "homepage": "https://docs.pimlico.io/permissionless",
-    "repository": "github:pimlicolabs/permissionless.js",
-    "main": "./_cjs/index.js",
-    "module": "./_esm/index.js",
-    "types": "./_types/index.d.ts",
-    "typings": "./_types/index.d.ts",
-    "type": "module",
-    "sideEffects": false,
-    "description": "A utility library for working with ERC-4337",
-    "keywords": ["ethereum", "erc-4337", "eip-4337", "paymaster", "bundler"],
-    "license": "MIT",
-    "exports": {
-        ".": {
-            "types": "./_types/index.d.ts",
-            "import": "./_esm/index.js",
-            "default": "./_cjs/index.js"
-        },
-        "./accounts": {
-            "types": "./_types/accounts/index.d.ts",
-            "import": "./_esm/accounts/index.js",
-            "default": "./_cjs/accounts/index.js"
-        },
-        "./accounts/safe": {
-            "types": "./_types/accounts/safe/index.d.ts",
-            "import": "./_esm/accounts/safe/index.js",
-            "default": "./_cjs/accounts/safe/index.js"
-        },
-        "./actions": {
-            "types": "./_types/actions/index.d.ts",
-            "import": "./_esm/actions/index.js",
-            "default": "./_cjs/actions/index.js"
-        },
-        "./actions/erc7579": {
-            "types": "./_types/actions/erc7579.d.ts",
-            "import": "./_esm/actions/erc7579.js",
-            "default": "./_cjs/actions/erc7579.js"
-        },
-        "./actions/pimlico": {
-            "types": "./_types/actions/pimlico.d.ts",
-            "import": "./_esm/actions/pimlico.js",
-            "default": "./_cjs/actions/pimlico.js"
-        },
-        "./actions/passkeyServer": {
-            "types": "./_types/actions/passkeyServer.d.ts",
-            "import": "./_esm/actions/passkeyServer.js",
-            "default": "./_cjs/actions/passkeyServer.js"
-        },
-        "./actions/etherspot": {
-            "types": "./_types/actions/etherspot.d.ts",
-            "import": "./_esm/actions/etherspot.js",
-            "default": "./_cjs/actions/etherspot.js"
-        },
-        "./actions/smartAccount": {
-            "types": "./_types/actions/smartAccount.d.ts",
-            "import": "./_esm/actions/smartAccount.js",
-            "default": "./_cjs/actions/smartAccount.js"
-        },
-        "./clients": {
-            "types": "./_types/clients/index.d.ts",
-            "import": "./_esm/clients/index.js",
-            "default": "./_cjs/clients/index.js"
-        },
-        "./clients/pimlico": {
-            "types": "./_types/clients/pimlico.d.ts",
-            "import": "./_esm/clients/pimlico.js",
-            "default": "./_cjs/clients/pimlico.js"
-        },
-        "./clients/passkeyServer": {
-            "types": "./_types/clients/passkeyServer.d.ts",
-            "import": "./_esm/clients/passkeyServer.js",
-            "default": "./_cjs/clients/passkeyServer.js"
-        },
-        "./utils": {
-            "types": "./_types/utils/index.d.ts",
-            "import": "./_esm/utils/index.js",
-            "default": "./_cjs/utils/index.js"
-        },
-        "./errors": {
-            "types": "./_types/errors/index.d.ts",
-            "import": "./_esm/errors/index.js",
-            "default": "./_cjs/errors/index.js"
-        },
-        "./experimental/pimlico": {
-            "types": "./_types/experimental/pimlico/index.d.ts",
-            "import": "./_esm/experimental/pimlico/index.js",
-            "default": "./_cjs/experimental/pimlico/index.js"
-        }
+  "name": "permissionless",
+  "version": "0.3.5",
+  "author": "Pimlico",
+  "homepage": "https://docs.pimlico.io/permissionless",
+  "repository": "github:pimlicolabs/permissionless.js",
+  "main": "./_cjs/index.js",
+  "module": "./_esm/index.js",
+  "types": "./_types/index.d.ts",
+  "typings": "./_types/index.d.ts",
+  "type": "module",
+  "sideEffects": false,
+  "description": "A utility library for working with ERC-4337",
+  "keywords": [
+    "ethereum",
+    "erc-4337",
+    "eip-4337",
+    "paymaster",
+    "bundler"
+  ],
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./_types/index.d.ts",
+      "import": "./_esm/index.js",
+      "default": "./_cjs/index.js"
     },
-    "peerDependencies": {
-        "viem": "^2.44.4",
-        "ox": "^0.11.3"
+    "./accounts": {
+      "types": "./_types/accounts/index.d.ts",
+      "import": "./_esm/accounts/index.js",
+      "default": "./_cjs/accounts/index.js"
     },
-    "peerDependenciesMeta": {
-        "ox": {
-            "optional": true
-        }
+    "./accounts/kernel/utils": {
+      "types": "./_types/accounts/kernel/utils/index.d.ts",
+      "import": "./_esm/accounts/kernel/utils/index.js",
+      "default": "./_cjs/accounts/kernel/utils/index.js"
+    },
+    "./accounts/safe": {
+      "types": "./_types/accounts/safe/index.d.ts",
+      "import": "./_esm/accounts/safe/index.js",
+      "default": "./_cjs/accounts/safe/index.js"
+    },
+    "./actions": {
+      "types": "./_types/actions/index.d.ts",
+      "import": "./_esm/actions/index.js",
+      "default": "./_cjs/actions/index.js"
+    },
+    "./actions/erc7579": {
+      "types": "./_types/actions/erc7579.d.ts",
+      "import": "./_esm/actions/erc7579.js",
+      "default": "./_cjs/actions/erc7579.js"
+    },
+    "./actions/pimlico": {
+      "types": "./_types/actions/pimlico.d.ts",
+      "import": "./_esm/actions/pimlico.js",
+      "default": "./_cjs/actions/pimlico.js"
+    },
+    "./actions/passkeyServer": {
+      "types": "./_types/actions/passkeyServer.d.ts",
+      "import": "./_esm/actions/passkeyServer.js",
+      "default": "./_cjs/actions/passkeyServer.js"
+    },
+    "./actions/etherspot": {
+      "types": "./_types/actions/etherspot.d.ts",
+      "import": "./_esm/actions/etherspot.js",
+      "default": "./_cjs/actions/etherspot.js"
+    },
+    "./actions/smartAccount": {
+      "types": "./_types/actions/smartAccount.d.ts",
+      "import": "./_esm/actions/smartAccount.js",
+      "default": "./_cjs/actions/smartAccount.js"
+    },
+    "./clients": {
+      "types": "./_types/clients/index.d.ts",
+      "import": "./_esm/clients/index.js",
+      "default": "./_cjs/clients/index.js"
+    },
+    "./clients/pimlico": {
+      "types": "./_types/clients/pimlico.d.ts",
+      "import": "./_esm/clients/pimlico.js",
+      "default": "./_cjs/clients/pimlico.js"
+    },
+    "./clients/passkeyServer": {
+      "types": "./_types/clients/passkeyServer.d.ts",
+      "import": "./_esm/clients/passkeyServer.js",
+      "default": "./_cjs/clients/passkeyServer.js"
+    },
+    "./utils": {
+      "types": "./_types/utils/index.d.ts",
+      "import": "./_esm/utils/index.js",
+      "default": "./_cjs/utils/index.js"
+    },
+    "./errors": {
+      "types": "./_types/errors/index.d.ts",
+      "import": "./_esm/errors/index.js",
+      "default": "./_cjs/errors/index.js"
+    },
+    "./experimental/pimlico": {
+      "types": "./_types/experimental/pimlico/index.d.ts",
+      "import": "./_esm/experimental/pimlico/index.js",
+      "default": "./_cjs/experimental/pimlico/index.js"
     }
+  },
+  "peerDependencies": {
+    "viem": "^2.44.4",
+    "ox": "^0.11.3"
+  },
+  "peerDependenciesMeta": {
+    "ox": {
+      "optional": true
+    }
+  }
 }

--- a/packages/permissionless/package.json
+++ b/packages/permissionless/package.json
@@ -1,113 +1,107 @@
 {
-  "name": "permissionless",
-  "version": "0.3.5",
-  "author": "Pimlico",
-  "homepage": "https://docs.pimlico.io/permissionless",
-  "repository": "github:pimlicolabs/permissionless.js",
-  "main": "./_cjs/index.js",
-  "module": "./_esm/index.js",
-  "types": "./_types/index.d.ts",
-  "typings": "./_types/index.d.ts",
-  "type": "module",
-  "sideEffects": false,
-  "description": "A utility library for working with ERC-4337",
-  "keywords": [
-    "ethereum",
-    "erc-4337",
-    "eip-4337",
-    "paymaster",
-    "bundler"
-  ],
-  "license": "MIT",
-  "exports": {
-    ".": {
-      "types": "./_types/index.d.ts",
-      "import": "./_esm/index.js",
-      "default": "./_cjs/index.js"
+    "name": "permissionless",
+    "version": "0.3.5",
+    "author": "Pimlico",
+    "homepage": "https://docs.pimlico.io/permissionless",
+    "repository": "github:pimlicolabs/permissionless.js",
+    "main": "./_cjs/index.js",
+    "module": "./_esm/index.js",
+    "types": "./_types/index.d.ts",
+    "typings": "./_types/index.d.ts",
+    "type": "module",
+    "sideEffects": false,
+    "description": "A utility library for working with ERC-4337",
+    "keywords": ["ethereum", "erc-4337", "eip-4337", "paymaster", "bundler"],
+    "license": "MIT",
+    "exports": {
+        ".": {
+            "types": "./_types/index.d.ts",
+            "import": "./_esm/index.js",
+            "default": "./_cjs/index.js"
+        },
+        "./accounts": {
+            "types": "./_types/accounts/index.d.ts",
+            "import": "./_esm/accounts/index.js",
+            "default": "./_cjs/accounts/index.js"
+        },
+        "./accounts/kernel/utils": {
+            "types": "./_types/accounts/kernel/utils/index.d.ts",
+            "import": "./_esm/accounts/kernel/utils/index.js",
+            "default": "./_cjs/accounts/kernel/utils/index.js"
+        },
+        "./accounts/safe": {
+            "types": "./_types/accounts/safe/index.d.ts",
+            "import": "./_esm/accounts/safe/index.js",
+            "default": "./_cjs/accounts/safe/index.js"
+        },
+        "./actions": {
+            "types": "./_types/actions/index.d.ts",
+            "import": "./_esm/actions/index.js",
+            "default": "./_cjs/actions/index.js"
+        },
+        "./actions/erc7579": {
+            "types": "./_types/actions/erc7579.d.ts",
+            "import": "./_esm/actions/erc7579.js",
+            "default": "./_cjs/actions/erc7579.js"
+        },
+        "./actions/pimlico": {
+            "types": "./_types/actions/pimlico.d.ts",
+            "import": "./_esm/actions/pimlico.js",
+            "default": "./_cjs/actions/pimlico.js"
+        },
+        "./actions/passkeyServer": {
+            "types": "./_types/actions/passkeyServer.d.ts",
+            "import": "./_esm/actions/passkeyServer.js",
+            "default": "./_cjs/actions/passkeyServer.js"
+        },
+        "./actions/etherspot": {
+            "types": "./_types/actions/etherspot.d.ts",
+            "import": "./_esm/actions/etherspot.js",
+            "default": "./_cjs/actions/etherspot.js"
+        },
+        "./actions/smartAccount": {
+            "types": "./_types/actions/smartAccount.d.ts",
+            "import": "./_esm/actions/smartAccount.js",
+            "default": "./_cjs/actions/smartAccount.js"
+        },
+        "./clients": {
+            "types": "./_types/clients/index.d.ts",
+            "import": "./_esm/clients/index.js",
+            "default": "./_cjs/clients/index.js"
+        },
+        "./clients/pimlico": {
+            "types": "./_types/clients/pimlico.d.ts",
+            "import": "./_esm/clients/pimlico.js",
+            "default": "./_cjs/clients/pimlico.js"
+        },
+        "./clients/passkeyServer": {
+            "types": "./_types/clients/passkeyServer.d.ts",
+            "import": "./_esm/clients/passkeyServer.js",
+            "default": "./_cjs/clients/passkeyServer.js"
+        },
+        "./utils": {
+            "types": "./_types/utils/index.d.ts",
+            "import": "./_esm/utils/index.js",
+            "default": "./_cjs/utils/index.js"
+        },
+        "./errors": {
+            "types": "./_types/errors/index.d.ts",
+            "import": "./_esm/errors/index.js",
+            "default": "./_cjs/errors/index.js"
+        },
+        "./experimental/pimlico": {
+            "types": "./_types/experimental/pimlico/index.d.ts",
+            "import": "./_esm/experimental/pimlico/index.js",
+            "default": "./_cjs/experimental/pimlico/index.js"
+        }
     },
-    "./accounts": {
-      "types": "./_types/accounts/index.d.ts",
-      "import": "./_esm/accounts/index.js",
-      "default": "./_cjs/accounts/index.js"
+    "peerDependencies": {
+        "viem": "^2.44.4",
+        "ox": "^0.11.3"
     },
-    "./accounts/kernel/utils": {
-      "types": "./_types/accounts/kernel/utils/index.d.ts",
-      "import": "./_esm/accounts/kernel/utils/index.js",
-      "default": "./_cjs/accounts/kernel/utils/index.js"
-    },
-    "./accounts/safe": {
-      "types": "./_types/accounts/safe/index.d.ts",
-      "import": "./_esm/accounts/safe/index.js",
-      "default": "./_cjs/accounts/safe/index.js"
-    },
-    "./actions": {
-      "types": "./_types/actions/index.d.ts",
-      "import": "./_esm/actions/index.js",
-      "default": "./_cjs/actions/index.js"
-    },
-    "./actions/erc7579": {
-      "types": "./_types/actions/erc7579.d.ts",
-      "import": "./_esm/actions/erc7579.js",
-      "default": "./_cjs/actions/erc7579.js"
-    },
-    "./actions/pimlico": {
-      "types": "./_types/actions/pimlico.d.ts",
-      "import": "./_esm/actions/pimlico.js",
-      "default": "./_cjs/actions/pimlico.js"
-    },
-    "./actions/passkeyServer": {
-      "types": "./_types/actions/passkeyServer.d.ts",
-      "import": "./_esm/actions/passkeyServer.js",
-      "default": "./_cjs/actions/passkeyServer.js"
-    },
-    "./actions/etherspot": {
-      "types": "./_types/actions/etherspot.d.ts",
-      "import": "./_esm/actions/etherspot.js",
-      "default": "./_cjs/actions/etherspot.js"
-    },
-    "./actions/smartAccount": {
-      "types": "./_types/actions/smartAccount.d.ts",
-      "import": "./_esm/actions/smartAccount.js",
-      "default": "./_cjs/actions/smartAccount.js"
-    },
-    "./clients": {
-      "types": "./_types/clients/index.d.ts",
-      "import": "./_esm/clients/index.js",
-      "default": "./_cjs/clients/index.js"
-    },
-    "./clients/pimlico": {
-      "types": "./_types/clients/pimlico.d.ts",
-      "import": "./_esm/clients/pimlico.js",
-      "default": "./_cjs/clients/pimlico.js"
-    },
-    "./clients/passkeyServer": {
-      "types": "./_types/clients/passkeyServer.d.ts",
-      "import": "./_esm/clients/passkeyServer.js",
-      "default": "./_cjs/clients/passkeyServer.js"
-    },
-    "./utils": {
-      "types": "./_types/utils/index.d.ts",
-      "import": "./_esm/utils/index.js",
-      "default": "./_cjs/utils/index.js"
-    },
-    "./errors": {
-      "types": "./_types/errors/index.d.ts",
-      "import": "./_esm/errors/index.js",
-      "default": "./_cjs/errors/index.js"
-    },
-    "./experimental/pimlico": {
-      "types": "./_types/experimental/pimlico/index.d.ts",
-      "import": "./_esm/experimental/pimlico/index.js",
-      "default": "./_cjs/experimental/pimlico/index.js"
+    "peerDependenciesMeta": {
+        "ox": {
+            "optional": true
+        }
     }
-  },
-  "peerDependencies": {
-    "viem": "^2.44.4",
-    "ox": "^0.11.3"
-  },
-  "peerDependenciesMeta": {
-    "ox": {
-      "optional": true
-    }
-  }
 }


### PR DESCRIPTION
### Summary
Adds a public permissionless/accounts/kernel/utils entry point that exposes the low-level Kernel signing utilities:

- `wrapMessageHash`
- `signMessage` 
- `signTypedData`
- `isKernelV2`

We (Privy) have a use case where we'd like to generate signatures without using the object returned by `toKernelSmartAccount`.

### Motivation
Currently the only way to access this functionality is through undocumented deep imports (e.g. permissionless/_cjs/accounts/kernel/utils/signMessage.js), which breaks in strict bundlers like Turbopack that enforce the exports map.
