### PR TITLE
Expose utils for generating ERC-1271 signatures

### DIFF
--- a/.changeset/shaggy-falcons-roll.md
+++ b/.changeset/shaggy-falcons-roll.md
@@ -1,0 +1,5 @@
+---
+"permissionless": patch
+---
+
+Added namespace exports for each smart account and exposed Kernel's ERC-1271 helpers.

--- a/packages/permissionless/accounts/biconomy/index.ts
+++ b/packages/permissionless/accounts/biconomy/index.ts
@@ -1,0 +1,11 @@
+import { toBiconomySmartAccount } from "./toBiconomySmartAccount.js"
+
+export const BiconomySmartAccount = {
+    toBiconomySmartAccount
+}
+
+export type {
+    BiconomySmartAccountImplementation,
+    ToBiconomySmartAccountParameters,
+    ToBiconomySmartAccountReturnType
+} from "./toBiconomySmartAccount.js"

--- a/packages/permissionless/accounts/etherspot/index.ts
+++ b/packages/permissionless/accounts/etherspot/index.ts
@@ -1,0 +1,11 @@
+import { toEtherspotSmartAccount } from "./toEtherspotSmartAccount.js"
+
+export const EtherspotSmartAccount = {
+    toEtherspotSmartAccount
+}
+
+export type {
+    EtherspotSmartAccountImplementation,
+    ToEtherspotSmartAccountParameters,
+    ToEtherspotSmartAccountReturnType
+} from "./toEtherspotSmartAccount.js"

--- a/packages/permissionless/accounts/kernel/index.ts
+++ b/packages/permissionless/accounts/kernel/index.ts
@@ -1,0 +1,33 @@
+import { to7702KernelSmartAccount } from "./to7702KernelSmartAccount.js"
+import { toKernelSmartAccount } from "./toKernelSmartAccount.js"
+import { isKernelV2 } from "./utils/isKernelV2.js"
+import { signMessage } from "./utils/signMessage.js"
+import { signTypedData } from "./utils/signTypedData.js"
+import { wrapMessageHash } from "./utils/wrapMessageHash.js"
+
+export const KernelSmartAccount = {
+    toKernelSmartAccount,
+    to7702KernelSmartAccount,
+    wrapMessageHash,
+    signMessage,
+    signTypedData,
+    isKernelV2
+}
+
+export type {
+    KernelSmartAccountImplementation,
+    KernelVersion,
+    ToKernelSmartAccountParameters,
+    ToKernelSmartAccountReturnType
+} from "./toKernelSmartAccount.js"
+export type {
+    EcdsaKernelSmartAccountImplementation,
+    ToEcdsaKernelSmartAccountParameters,
+    ToEcdsaKernelSmartAccountReturnType
+} from "./toEcdsaKernelSmartAccount.js"
+export type {
+    To7702KernelSmartAccountImplementation,
+    To7702KernelSmartAccountParameters,
+    To7702KernelSmartAccountReturnType
+} from "./to7702KernelSmartAccount.js"
+export type { WrapMessageHashParams } from "./utils/wrapMessageHash.js"

--- a/packages/permissionless/accounts/kernel/toKernelSmartAccount.ts
+++ b/packages/permissionless/accounts/kernel/toKernelSmartAccount.ts
@@ -901,8 +901,8 @@ export async function toKernelSmartAccount<
             const signature = await signMessage({
                 owner,
                 message,
-                accountAddress: await this.getAddress(),
-                kernelVersion: kernelVersion,
+                address: await this.getAddress(),
+                version: kernelVersion,
                 chainId: await getMemoizedChainId(),
                 eip7702: eip7702
             })
@@ -931,8 +931,8 @@ export async function toKernelSmartAccount<
                 owner: owner,
                 chainId: await getMemoizedChainId(),
                 ...(typedData as TypedDataDefinition),
-                accountAddress: await this.getAddress(),
-                kernelVersion: kernelVersion,
+                address: await this.getAddress(),
+                version: kernelVersion,
                 eip7702
             })
 
@@ -966,8 +966,8 @@ export async function toKernelSmartAccount<
                       owner,
                       message: { raw: hash },
                       chainId,
-                      accountAddress: await this.getAddress(),
-                      kernelVersion,
+                      address: await this.getAddress(),
+                      version: kernelVersion,
                       eip7702: false
                   })
                 : await owner.signMessage({

--- a/packages/permissionless/accounts/kernel/utils/index.ts
+++ b/packages/permissionless/accounts/kernel/utils/index.ts
@@ -1,0 +1,7 @@
+export {
+  wrapMessageHash,
+  type WrapMessageHashParams,
+} from "./wrapMessageHash.js";
+export { signMessage } from "./signMessage.js";
+export { signTypedData } from "./signTypedData.js";
+export { isKernelV2 } from "./isKernelV2.js";

--- a/packages/permissionless/accounts/kernel/utils/index.ts
+++ b/packages/permissionless/accounts/kernel/utils/index.ts
@@ -1,7 +1,7 @@
 export {
-  wrapMessageHash,
-  type WrapMessageHashParams,
-} from "./wrapMessageHash.js";
-export { signMessage } from "./signMessage.js";
-export { signTypedData } from "./signTypedData.js";
-export { isKernelV2 } from "./isKernelV2.js";
+    wrapMessageHash,
+    type WrapMessageHashParams
+} from "./wrapMessageHash.js"
+export { signMessage } from "./signMessage.js"
+export { signTypedData } from "./signTypedData.js"
+export { isKernelV2 } from "./isKernelV2.js"

--- a/packages/permissionless/accounts/kernel/utils/index.ts
+++ b/packages/permissionless/accounts/kernel/utils/index.ts
@@ -1,7 +1,0 @@
-export {
-    wrapMessageHash,
-    type WrapMessageHashParams
-} from "./wrapMessageHash.js"
-export { signMessage } from "./signMessage.js"
-export { signTypedData } from "./signTypedData.js"
-export { isKernelV2 } from "./isKernelV2.js"

--- a/packages/permissionless/accounts/kernel/utils/signMessage.ts
+++ b/packages/permissionless/accounts/kernel/utils/signMessage.ts
@@ -22,12 +22,12 @@ export async function signMessage({
     address: accountAddress,
     version: accountVersion,
     chainId,
-    eip7702
+    eip7702 = false
 }: Prettify<
     {
         message: SignableMessage
         owner: LocalAccount | WebAuthnAccount
-        eip7702: boolean
+        eip7702?: boolean
     } & WrapMessageHashParams
 >): Promise<SignMessageReturnType> {
     if (isWebAuthnAccount(owner)) {

--- a/packages/permissionless/accounts/kernel/utils/signMessage.ts
+++ b/packages/permissionless/accounts/kernel/utils/signMessage.ts
@@ -1,6 +1,7 @@
 import {
     type Hash,
     type LocalAccount,
+    type Prettify,
     type SignMessageReturnType,
     type SignableMessage,
     encodeAbiParameters,
@@ -18,23 +19,25 @@ import {
 export async function signMessage({
     message,
     owner,
-    accountAddress,
-    kernelVersion: accountVersion,
+    address: accountAddress,
+    version: accountVersion,
     chainId,
     eip7702
-}: {
-    chainId: number
-    message: SignableMessage
-    owner: LocalAccount | WebAuthnAccount
-    eip7702: boolean
-} & WrapMessageHashParams): Promise<SignMessageReturnType> {
+}: Prettify<
+    {
+        message: SignableMessage
+        owner: LocalAccount | WebAuthnAccount
+        eip7702: boolean
+    } & WrapMessageHashParams
+>): Promise<SignMessageReturnType> {
     if (isWebAuthnAccount(owner)) {
         let messageContent: string
         if (typeof message === "string") {
             // message is a string
-            messageContent = wrapMessageHash(hashMessage(message), {
-                kernelVersion: accountVersion,
-                accountAddress,
+            messageContent = wrapMessageHash({
+                hash: hashMessage(message),
+                version: accountVersion,
+                address: accountAddress,
                 chainId
                 // chainId: client.chain
                 //     ? client.chain.id
@@ -100,9 +103,10 @@ export async function signMessage({
         })
     }
 
-    const wrappedMessageHash = wrapMessageHash(hashMessage(message), {
-        kernelVersion: accountVersion,
-        accountAddress,
+    const wrappedMessageHash = wrapMessageHash({
+        hash: hashMessage(message),
+        version: accountVersion,
+        address: accountAddress,
         chainId
         // chainId: client.chain
         //     ? client.chain.id

--- a/packages/permissionless/accounts/kernel/utils/signTypedData.ts
+++ b/packages/permissionless/accounts/kernel/utils/signTypedData.ts
@@ -19,7 +19,7 @@ export async function signTypedData(
     parameters: Prettify<
         WrapMessageHashParams & {
             owner: LocalAccount | WebAuthnAccount
-            eip7702: boolean
+            eip7702?: boolean
         } & TypedDataDefinition
     >
 ): Promise<SignTypedDataReturnType> {
@@ -28,7 +28,7 @@ export async function signTypedData(
         address: accountAddress,
         version: accountVersion,
         chainId,
-        eip7702,
+        eip7702 = false,
         ...typedData
     } = parameters
 

--- a/packages/permissionless/accounts/kernel/utils/signTypedData.ts
+++ b/packages/permissionless/accounts/kernel/utils/signTypedData.ts
@@ -1,5 +1,6 @@
 import {
     type LocalAccount,
+    type Prettify,
     type SignTypedDataReturnType,
     type TypedDataDefinition,
     getTypesForEIP712Domain,
@@ -15,16 +16,17 @@ import {
 } from "./wrapMessageHash.js"
 
 export async function signTypedData(
-    parameters: TypedDataDefinition &
+    parameters: Prettify<
         WrapMessageHashParams & {
             owner: LocalAccount | WebAuthnAccount
             eip7702: boolean
-        }
+        } & TypedDataDefinition
+    >
 ): Promise<SignTypedDataReturnType> {
     const {
         owner,
-        accountAddress,
-        kernelVersion: accountVersion,
+        address: accountAddress,
+        version: accountVersion,
         chainId,
         eip7702,
         ...typedData
@@ -74,9 +76,10 @@ export async function signTypedData(
         })
     }
 
-    const wrappedMessageHash = wrapMessageHash(typedHash, {
-        kernelVersion: accountVersion,
-        accountAddress,
+    const wrappedMessageHash = wrapMessageHash({
+        hash: typedHash,
+        version: accountVersion,
+        address: accountAddress,
         chainId: chainId
     })
 
@@ -84,8 +87,8 @@ export async function signTypedData(
         return signMessage({
             message: { raw: wrappedMessageHash },
             owner,
-            accountAddress,
-            kernelVersion: accountVersion,
+            address: accountAddress,
+            version: accountVersion,
             chainId,
             eip7702: false
         })

--- a/packages/permissionless/accounts/kernel/utils/wrapMessageHash.ts
+++ b/packages/permissionless/accounts/kernel/utils/wrapMessageHash.ts
@@ -1,6 +1,7 @@
 import {
     type Address,
     type Hex,
+    type Prettify,
     concatHex,
     domainSeparator,
     encodeAbiParameters,
@@ -11,15 +12,17 @@ import type { KernelVersion } from "../toKernelSmartAccount.js"
 import { isKernelV2 } from "./isKernelV2.js"
 
 export type WrapMessageHashParams = {
-    kernelVersion: KernelVersion<"0.6" | "0.7">
-    accountAddress: Address
+    version: KernelVersion<"0.6" | "0.7">
+    address: Address
     chainId: number
 }
 
-export const wrapMessageHash = (
-    messageHash: Hex,
-    { accountAddress, kernelVersion, chainId }: WrapMessageHashParams
-) => {
+export const wrapMessageHash = ({
+    hash,
+    address: accountAddress,
+    version: kernelVersion,
+    chainId
+}: Prettify<{ hash: Hex } & WrapMessageHashParams>) => {
     const _domainSeparator = domainSeparator({
         domain: {
             name: "Kernel",
@@ -29,11 +32,11 @@ export const wrapMessageHash = (
         }
     })
     const wrappedMessageHash = isKernelV2(kernelVersion)
-        ? messageHash
+        ? hash
         : keccak256(
               encodeAbiParameters(
                   [{ type: "bytes32" }, { type: "bytes32" }],
-                  [keccak256(stringToHex("Kernel(bytes32 hash)")), messageHash]
+                  [keccak256(stringToHex("Kernel(bytes32 hash)")), hash]
               )
           )
 

--- a/packages/permissionless/accounts/light/index.ts
+++ b/packages/permissionless/accounts/light/index.ts
@@ -1,0 +1,12 @@
+import { toLightSmartAccount } from "./toLightSmartAccount.js"
+
+export const LightSmartAccount = {
+    toLightSmartAccount
+}
+
+export type {
+    LightAccountVersion,
+    LightSmartAccountImplementation,
+    ToLightSmartAccountParameters,
+    ToLightSmartAccountReturnType
+} from "./toLightSmartAccount.js"

--- a/packages/permissionless/accounts/nexus/index.ts
+++ b/packages/permissionless/accounts/nexus/index.ts
@@ -1,0 +1,11 @@
+import { toNexusSmartAccount } from "./toNexusSmartAccount.js"
+
+export const NexusSmartAccount = {
+    toNexusSmartAccount
+}
+
+export type {
+    NexusSmartAccountImplementation,
+    ToNexusSmartAccountParameters,
+    ToNexusSmartAccountReturnType
+} from "./toNexusSmartAccount.js"

--- a/packages/permissionless/accounts/simple/index.ts
+++ b/packages/permissionless/accounts/simple/index.ts
@@ -1,0 +1,18 @@
+import { to7702SimpleSmartAccount } from "./to7702SimpleSmartAccount.js"
+import { toSimpleSmartAccount } from "./toSimpleSmartAccount.js"
+
+export const SimpleSmartAccount = {
+    toSimpleSmartAccount,
+    to7702SimpleSmartAccount
+}
+
+export type {
+    SimpleSmartAccountImplementation,
+    ToSimpleSmartAccountParameters,
+    ToSimpleSmartAccountReturnType
+} from "./toSimpleSmartAccount.js"
+export type {
+    To7702SimpleSmartAccountImplementation,
+    To7702SimpleSmartAccountParameters,
+    To7702SimpleSmartAccountReturnType
+} from "./to7702SimpleSmartAccount.js"

--- a/packages/permissionless/accounts/thirdweb/index.ts
+++ b/packages/permissionless/accounts/thirdweb/index.ts
@@ -1,0 +1,11 @@
+import { toThirdwebSmartAccount } from "./toThirdwebSmartAccount.js"
+
+export const ThirdwebSmartAccount = {
+    toThirdwebSmartAccount
+}
+
+export type {
+    ThirdwebSmartAccountImplementation,
+    ToThirdwebSmartAccountParameters,
+    ToThirdwebSmartAccountReturnType
+} from "./toThirdwebSmartAccount.js"

--- a/packages/permissionless/accounts/trust/index.ts
+++ b/packages/permissionless/accounts/trust/index.ts
@@ -1,0 +1,11 @@
+import { toTrustSmartAccount } from "./toTrustSmartAccount.js"
+
+export const TrustSmartAccount = {
+    toTrustSmartAccount
+}
+
+export type {
+    ToTrustSmartAccountParameters,
+    ToTrustSmartAccountReturnType,
+    TrustSmartAccountImplementation
+} from "./toTrustSmartAccount.js"

--- a/packages/permissionless/package.json
+++ b/packages/permissionless/package.json
@@ -1,102 +1,113 @@
 {
-    "name": "permissionless",
-    "version": "0.3.5",
-    "author": "Pimlico",
-    "homepage": "https://docs.pimlico.io/permissionless",
-    "repository": "github:pimlicolabs/permissionless.js",
-    "main": "./_cjs/index.js",
-    "module": "./_esm/index.js",
-    "types": "./_types/index.d.ts",
-    "typings": "./_types/index.d.ts",
-    "type": "module",
-    "sideEffects": false,
-    "description": "A utility library for working with ERC-4337",
-    "keywords": ["ethereum", "erc-4337", "eip-4337", "paymaster", "bundler"],
-    "license": "MIT",
-    "exports": {
-        ".": {
-            "types": "./_types/index.d.ts",
-            "import": "./_esm/index.js",
-            "default": "./_cjs/index.js"
-        },
-        "./accounts": {
-            "types": "./_types/accounts/index.d.ts",
-            "import": "./_esm/accounts/index.js",
-            "default": "./_cjs/accounts/index.js"
-        },
-        "./accounts/safe": {
-            "types": "./_types/accounts/safe/index.d.ts",
-            "import": "./_esm/accounts/safe/index.js",
-            "default": "./_cjs/accounts/safe/index.js"
-        },
-        "./actions": {
-            "types": "./_types/actions/index.d.ts",
-            "import": "./_esm/actions/index.js",
-            "default": "./_cjs/actions/index.js"
-        },
-        "./actions/erc7579": {
-            "types": "./_types/actions/erc7579.d.ts",
-            "import": "./_esm/actions/erc7579.js",
-            "default": "./_cjs/actions/erc7579.js"
-        },
-        "./actions/pimlico": {
-            "types": "./_types/actions/pimlico.d.ts",
-            "import": "./_esm/actions/pimlico.js",
-            "default": "./_cjs/actions/pimlico.js"
-        },
-        "./actions/passkeyServer": {
-            "types": "./_types/actions/passkeyServer.d.ts",
-            "import": "./_esm/actions/passkeyServer.js",
-            "default": "./_cjs/actions/passkeyServer.js"
-        },
-        "./actions/etherspot": {
-            "types": "./_types/actions/etherspot.d.ts",
-            "import": "./_esm/actions/etherspot.js",
-            "default": "./_cjs/actions/etherspot.js"
-        },
-        "./actions/smartAccount": {
-            "types": "./_types/actions/smartAccount.d.ts",
-            "import": "./_esm/actions/smartAccount.js",
-            "default": "./_cjs/actions/smartAccount.js"
-        },
-        "./clients": {
-            "types": "./_types/clients/index.d.ts",
-            "import": "./_esm/clients/index.js",
-            "default": "./_cjs/clients/index.js"
-        },
-        "./clients/pimlico": {
-            "types": "./_types/clients/pimlico.d.ts",
-            "import": "./_esm/clients/pimlico.js",
-            "default": "./_cjs/clients/pimlico.js"
-        },
-        "./clients/passkeyServer": {
-            "types": "./_types/clients/passkeyServer.d.ts",
-            "import": "./_esm/clients/passkeyServer.js",
-            "default": "./_cjs/clients/passkeyServer.js"
-        },
-        "./utils": {
-            "types": "./_types/utils/index.d.ts",
-            "import": "./_esm/utils/index.js",
-            "default": "./_cjs/utils/index.js"
-        },
-        "./errors": {
-            "types": "./_types/errors/index.d.ts",
-            "import": "./_esm/errors/index.js",
-            "default": "./_cjs/errors/index.js"
-        },
-        "./experimental/pimlico": {
-            "types": "./_types/experimental/pimlico/index.d.ts",
-            "import": "./_esm/experimental/pimlico/index.js",
-            "default": "./_cjs/experimental/pimlico/index.js"
-        }
+  "name": "permissionless",
+  "version": "0.3.5",
+  "author": "Pimlico",
+  "homepage": "https://docs.pimlico.io/permissionless",
+  "repository": "github:pimlicolabs/permissionless.js",
+  "main": "./_cjs/index.js",
+  "module": "./_esm/index.js",
+  "types": "./_types/index.d.ts",
+  "typings": "./_types/index.d.ts",
+  "type": "module",
+  "sideEffects": false,
+  "description": "A utility library for working with ERC-4337",
+  "keywords": [
+    "ethereum",
+    "erc-4337",
+    "eip-4337",
+    "paymaster",
+    "bundler"
+  ],
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./_types/index.d.ts",
+      "import": "./_esm/index.js",
+      "default": "./_cjs/index.js"
     },
-    "peerDependencies": {
-        "viem": "^2.44.4",
-        "ox": "^0.11.3"
+    "./accounts": {
+      "types": "./_types/accounts/index.d.ts",
+      "import": "./_esm/accounts/index.js",
+      "default": "./_cjs/accounts/index.js"
     },
-    "peerDependenciesMeta": {
-        "ox": {
-            "optional": true
-        }
+    "./accounts/kernel/utils": {
+      "types": "./_types/accounts/kernel/utils/index.d.ts",
+      "import": "./_esm/accounts/kernel/utils/index.js",
+      "default": "./_cjs/accounts/kernel/utils/index.js"
+    },
+    "./accounts/safe": {
+      "types": "./_types/accounts/safe/index.d.ts",
+      "import": "./_esm/accounts/safe/index.js",
+      "default": "./_cjs/accounts/safe/index.js"
+    },
+    "./actions": {
+      "types": "./_types/actions/index.d.ts",
+      "import": "./_esm/actions/index.js",
+      "default": "./_cjs/actions/index.js"
+    },
+    "./actions/erc7579": {
+      "types": "./_types/actions/erc7579.d.ts",
+      "import": "./_esm/actions/erc7579.js",
+      "default": "./_cjs/actions/erc7579.js"
+    },
+    "./actions/pimlico": {
+      "types": "./_types/actions/pimlico.d.ts",
+      "import": "./_esm/actions/pimlico.js",
+      "default": "./_cjs/actions/pimlico.js"
+    },
+    "./actions/passkeyServer": {
+      "types": "./_types/actions/passkeyServer.d.ts",
+      "import": "./_esm/actions/passkeyServer.js",
+      "default": "./_cjs/actions/passkeyServer.js"
+    },
+    "./actions/etherspot": {
+      "types": "./_types/actions/etherspot.d.ts",
+      "import": "./_esm/actions/etherspot.js",
+      "default": "./_cjs/actions/etherspot.js"
+    },
+    "./actions/smartAccount": {
+      "types": "./_types/actions/smartAccount.d.ts",
+      "import": "./_esm/actions/smartAccount.js",
+      "default": "./_cjs/actions/smartAccount.js"
+    },
+    "./clients": {
+      "types": "./_types/clients/index.d.ts",
+      "import": "./_esm/clients/index.js",
+      "default": "./_cjs/clients/index.js"
+    },
+    "./clients/pimlico": {
+      "types": "./_types/clients/pimlico.d.ts",
+      "import": "./_esm/clients/pimlico.js",
+      "default": "./_cjs/clients/pimlico.js"
+    },
+    "./clients/passkeyServer": {
+      "types": "./_types/clients/passkeyServer.d.ts",
+      "import": "./_esm/clients/passkeyServer.js",
+      "default": "./_cjs/clients/passkeyServer.js"
+    },
+    "./utils": {
+      "types": "./_types/utils/index.d.ts",
+      "import": "./_esm/utils/index.js",
+      "default": "./_cjs/utils/index.js"
+    },
+    "./errors": {
+      "types": "./_types/errors/index.d.ts",
+      "import": "./_esm/errors/index.js",
+      "default": "./_cjs/errors/index.js"
+    },
+    "./experimental/pimlico": {
+      "types": "./_types/experimental/pimlico/index.d.ts",
+      "import": "./_esm/experimental/pimlico/index.js",
+      "default": "./_cjs/experimental/pimlico/index.js"
     }
+  },
+  "peerDependencies": {
+    "viem": "^2.44.4",
+    "ox": "^0.11.3"
+  },
+  "peerDependenciesMeta": {
+    "ox": {
+      "optional": true
+    }
+  }
 }

--- a/packages/permissionless/package.json
+++ b/packages/permissionless/package.json
@@ -1,113 +1,107 @@
 {
-  "name": "permissionless",
-  "version": "0.3.5",
-  "author": "Pimlico",
-  "homepage": "https://docs.pimlico.io/permissionless",
-  "repository": "github:pimlicolabs/permissionless.js",
-  "main": "./_cjs/index.js",
-  "module": "./_esm/index.js",
-  "types": "./_types/index.d.ts",
-  "typings": "./_types/index.d.ts",
-  "type": "module",
-  "sideEffects": false,
-  "description": "A utility library for working with ERC-4337",
-  "keywords": [
-    "ethereum",
-    "erc-4337",
-    "eip-4337",
-    "paymaster",
-    "bundler"
-  ],
-  "license": "MIT",
-  "exports": {
-    ".": {
-      "types": "./_types/index.d.ts",
-      "import": "./_esm/index.js",
-      "default": "./_cjs/index.js"
+    "name": "permissionless",
+    "version": "0.3.5",
+    "author": "Pimlico",
+    "homepage": "https://docs.pimlico.io/permissionless",
+    "repository": "github:pimlicolabs/permissionless.js",
+    "main": "./_cjs/index.js",
+    "module": "./_esm/index.js",
+    "types": "./_types/index.d.ts",
+    "typings": "./_types/index.d.ts",
+    "type": "module",
+    "sideEffects": false,
+    "description": "A utility library for working with ERC-4337",
+    "keywords": ["ethereum", "erc-4337", "eip-4337", "paymaster", "bundler"],
+    "license": "MIT",
+    "exports": {
+        ".": {
+            "types": "./_types/index.d.ts",
+            "import": "./_esm/index.js",
+            "default": "./_cjs/index.js"
+        },
+        "./accounts": {
+            "types": "./_types/accounts/index.d.ts",
+            "import": "./_esm/accounts/index.js",
+            "default": "./_cjs/accounts/index.js"
+        },
+        "./accounts/kernel/utils": {
+            "types": "./_types/accounts/kernel/utils/index.d.ts",
+            "import": "./_esm/accounts/kernel/utils/index.js",
+            "default": "./_cjs/accounts/kernel/utils/index.js"
+        },
+        "./accounts/safe": {
+            "types": "./_types/accounts/safe/index.d.ts",
+            "import": "./_esm/accounts/safe/index.js",
+            "default": "./_cjs/accounts/safe/index.js"
+        },
+        "./actions": {
+            "types": "./_types/actions/index.d.ts",
+            "import": "./_esm/actions/index.js",
+            "default": "./_cjs/actions/index.js"
+        },
+        "./actions/erc7579": {
+            "types": "./_types/actions/erc7579.d.ts",
+            "import": "./_esm/actions/erc7579.js",
+            "default": "./_cjs/actions/erc7579.js"
+        },
+        "./actions/pimlico": {
+            "types": "./_types/actions/pimlico.d.ts",
+            "import": "./_esm/actions/pimlico.js",
+            "default": "./_cjs/actions/pimlico.js"
+        },
+        "./actions/passkeyServer": {
+            "types": "./_types/actions/passkeyServer.d.ts",
+            "import": "./_esm/actions/passkeyServer.js",
+            "default": "./_cjs/actions/passkeyServer.js"
+        },
+        "./actions/etherspot": {
+            "types": "./_types/actions/etherspot.d.ts",
+            "import": "./_esm/actions/etherspot.js",
+            "default": "./_cjs/actions/etherspot.js"
+        },
+        "./actions/smartAccount": {
+            "types": "./_types/actions/smartAccount.d.ts",
+            "import": "./_esm/actions/smartAccount.js",
+            "default": "./_cjs/actions/smartAccount.js"
+        },
+        "./clients": {
+            "types": "./_types/clients/index.d.ts",
+            "import": "./_esm/clients/index.js",
+            "default": "./_cjs/clients/index.js"
+        },
+        "./clients/pimlico": {
+            "types": "./_types/clients/pimlico.d.ts",
+            "import": "./_esm/clients/pimlico.js",
+            "default": "./_cjs/clients/pimlico.js"
+        },
+        "./clients/passkeyServer": {
+            "types": "./_types/clients/passkeyServer.d.ts",
+            "import": "./_esm/clients/passkeyServer.js",
+            "default": "./_cjs/clients/passkeyServer.js"
+        },
+        "./utils": {
+            "types": "./_types/utils/index.d.ts",
+            "import": "./_esm/utils/index.js",
+            "default": "./_cjs/utils/index.js"
+        },
+        "./errors": {
+            "types": "./_types/errors/index.d.ts",
+            "import": "./_esm/errors/index.js",
+            "default": "./_cjs/errors/index.js"
+        },
+        "./experimental/pimlico": {
+            "types": "./_types/experimental/pimlico/index.d.ts",
+            "import": "./_esm/experimental/pimlico/index.js",
+            "default": "./_cjs/experimental/pimlico/index.js"
+        }
     },
-    "./accounts": {
-      "types": "./_types/accounts/index.d.ts",
-      "import": "./_esm/accounts/index.js",
-      "default": "./_cjs/accounts/index.js"
+    "peerDependencies": {
+        "viem": "^2.44.4",
+        "ox": "^0.11.3"
     },
-    "./accounts/kernel/utils": {
-      "types": "./_types/accounts/kernel/utils/index.d.ts",
-      "import": "./_esm/accounts/kernel/utils/index.js",
-      "default": "./_cjs/accounts/kernel/utils/index.js"
-    },
-    "./accounts/safe": {
-      "types": "./_types/accounts/safe/index.d.ts",
-      "import": "./_esm/accounts/safe/index.js",
-      "default": "./_cjs/accounts/safe/index.js"
-    },
-    "./actions": {
-      "types": "./_types/actions/index.d.ts",
-      "import": "./_esm/actions/index.js",
-      "default": "./_cjs/actions/index.js"
-    },
-    "./actions/erc7579": {
-      "types": "./_types/actions/erc7579.d.ts",
-      "import": "./_esm/actions/erc7579.js",
-      "default": "./_cjs/actions/erc7579.js"
-    },
-    "./actions/pimlico": {
-      "types": "./_types/actions/pimlico.d.ts",
-      "import": "./_esm/actions/pimlico.js",
-      "default": "./_cjs/actions/pimlico.js"
-    },
-    "./actions/passkeyServer": {
-      "types": "./_types/actions/passkeyServer.d.ts",
-      "import": "./_esm/actions/passkeyServer.js",
-      "default": "./_cjs/actions/passkeyServer.js"
-    },
-    "./actions/etherspot": {
-      "types": "./_types/actions/etherspot.d.ts",
-      "import": "./_esm/actions/etherspot.js",
-      "default": "./_cjs/actions/etherspot.js"
-    },
-    "./actions/smartAccount": {
-      "types": "./_types/actions/smartAccount.d.ts",
-      "import": "./_esm/actions/smartAccount.js",
-      "default": "./_cjs/actions/smartAccount.js"
-    },
-    "./clients": {
-      "types": "./_types/clients/index.d.ts",
-      "import": "./_esm/clients/index.js",
-      "default": "./_cjs/clients/index.js"
-    },
-    "./clients/pimlico": {
-      "types": "./_types/clients/pimlico.d.ts",
-      "import": "./_esm/clients/pimlico.js",
-      "default": "./_cjs/clients/pimlico.js"
-    },
-    "./clients/passkeyServer": {
-      "types": "./_types/clients/passkeyServer.d.ts",
-      "import": "./_esm/clients/passkeyServer.js",
-      "default": "./_cjs/clients/passkeyServer.js"
-    },
-    "./utils": {
-      "types": "./_types/utils/index.d.ts",
-      "import": "./_esm/utils/index.js",
-      "default": "./_cjs/utils/index.js"
-    },
-    "./errors": {
-      "types": "./_types/errors/index.d.ts",
-      "import": "./_esm/errors/index.js",
-      "default": "./_cjs/errors/index.js"
-    },
-    "./experimental/pimlico": {
-      "types": "./_types/experimental/pimlico/index.d.ts",
-      "import": "./_esm/experimental/pimlico/index.js",
-      "default": "./_cjs/experimental/pimlico/index.js"
+    "peerDependenciesMeta": {
+        "ox": {
+            "optional": true
+        }
     }
-  },
-  "peerDependencies": {
-    "viem": "^2.44.4",
-    "ox": "^0.11.3"
-  },
-  "peerDependenciesMeta": {
-    "ox": {
-      "optional": true
-    }
-  }
 }

--- a/packages/permissionless/package.json
+++ b/packages/permissionless/package.json
@@ -24,15 +24,50 @@
             "import": "./_esm/accounts/index.js",
             "default": "./_cjs/accounts/index.js"
         },
-        "./accounts/kernel/utils": {
-            "types": "./_types/accounts/kernel/utils/index.d.ts",
-            "import": "./_esm/accounts/kernel/utils/index.js",
-            "default": "./_cjs/accounts/kernel/utils/index.js"
+        "./accounts/biconomy": {
+            "types": "./_types/accounts/biconomy/index.d.ts",
+            "import": "./_esm/accounts/biconomy/index.js",
+            "default": "./_cjs/accounts/biconomy/index.js"
+        },
+        "./accounts/etherspot": {
+            "types": "./_types/accounts/etherspot/index.d.ts",
+            "import": "./_esm/accounts/etherspot/index.js",
+            "default": "./_cjs/accounts/etherspot/index.js"
+        },
+        "./accounts/kernel": {
+            "types": "./_types/accounts/kernel/index.d.ts",
+            "import": "./_esm/accounts/kernel/index.js",
+            "default": "./_cjs/accounts/kernel/index.js"
+        },
+        "./accounts/light": {
+            "types": "./_types/accounts/light/index.d.ts",
+            "import": "./_esm/accounts/light/index.js",
+            "default": "./_cjs/accounts/light/index.js"
+        },
+        "./accounts/nexus": {
+            "types": "./_types/accounts/nexus/index.d.ts",
+            "import": "./_esm/accounts/nexus/index.js",
+            "default": "./_cjs/accounts/nexus/index.js"
         },
         "./accounts/safe": {
             "types": "./_types/accounts/safe/index.d.ts",
             "import": "./_esm/accounts/safe/index.js",
             "default": "./_cjs/accounts/safe/index.js"
+        },
+        "./accounts/simple": {
+            "types": "./_types/accounts/simple/index.d.ts",
+            "import": "./_esm/accounts/simple/index.js",
+            "default": "./_cjs/accounts/simple/index.js"
+        },
+        "./accounts/thirdweb": {
+            "types": "./_types/accounts/thirdweb/index.d.ts",
+            "import": "./_esm/accounts/thirdweb/index.js",
+            "default": "./_cjs/accounts/thirdweb/index.js"
+        },
+        "./accounts/trust": {
+            "types": "./_types/accounts/trust/index.d.ts",
+            "import": "./_esm/accounts/trust/index.js",
+            "default": "./_cjs/accounts/trust/index.js"
         },
         "./actions": {
             "types": "./_types/actions/index.d.ts",

--- a/packages/permissionless/vitest.config.ts
+++ b/packages/permissionless/vitest.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
                 "**/permissionless-test/**",
                 "**/_cjs/**",
                 "**/_esm/**",
-                "**/_types/**"
+                "**/_types/**",
+                "**/permissionless/accounts/index.ts",
+                "**/permissionless/accounts/*/index.ts"
             ]
         },
         sequence: {


### PR DESCRIPTION
Updating https://github.com/pimlicolabs/permissionless.js/pull/513

```ts
  import { BiconomySmartAccount } from "permissionless/accounts/biconomy"
  import { EtherspotSmartAccount } from "permissionless/accounts/etherspot"
  import { KernelSmartAccount } from "permissionless/accounts/kernel"
  import { LightSmartAccount } from "permissionless/accounts/light"
  import { NexusSmartAccount } from "permissionless/accounts/nexus"
  import { SafeSmartAccount } from "permissionless/accounts/safe"
  import { SimpleSmartAccount } from "permissionless/accounts/simple"
  import { ThirdwebSmartAccount } from "permissionless/accounts/thirdweb"
  import { TrustSmartAccount } from "permissionless/accounts/trust"

  // Each one is a namespace object holding the constructors:

  const account = await SimpleSmartAccount.toSimpleSmartAccount({ client, owner, ...rest })
  const safe   = await SafeSmartAccount.toSafeSmartAccount({ client, owners, ...rest })

  // Kernel — full example with the utils:

  import {
      KernelSmartAccount,
      type WrapMessageHashParams
  } from "permissionless/accounts/kernel"

  // 1. Build a kernel account
  const account = await KernelSmartAccount.toKernelSmartAccount({
      client,
      owners: [owner],
      version: "0.3.1"
  })

  // 2. Wrap a raw hash with the kernel EIP-712 domain
  const wrapped = KernelSmartAccount.wrapMessageHash({
      hash: someHash,
      address: account.address,
      version: "0.3.1",
      chainId: 1
  })

  // 3. Sign a kernel-style message (handles eip-7702, WebAuthn, kernel v2/v3)
  const signature = await KernelSmartAccount.signMessage({
      message: { raw: someHash },
      owner,
      address: account.address,
      version: "0.3.1",
      chainId: 1,
      eip7702: false
  })

  // 4. Sign typed data through the kernel wrapper
  const typedSig = await KernelSmartAccount.signTypedData({
      owner,
      address: account.address,
      version: "0.3.1",
      chainId: 1,
      eip7702: false,
      domain: { ... },
      types: { ... },
      primaryType: "Mail",
      message: { ... }
  })

  // 5. Branch on kernel version
  if (KernelSmartAccount.isKernelV2("0.2.4")) {
      // v2-specific path
  }
  ```