### PR TITLE
Fix thirdweb account address comparison

### DIFF
--- a/.changeset/thirdweb-address-compare.md
+++ b/.changeset/thirdweb-address-compare.md
@@ -1,0 +1,5 @@
+---
+"permissionless": patch
+---
+
+Fix case-sensitive address comparison in thirdweb signTypedData self-verifying contract check

--- a/packages/permissionless/accounts/thirdweb/utils/signTypedData.ts
+++ b/packages/permissionless/accounts/thirdweb/utils/signTypedData.ts
@@ -7,6 +7,7 @@ import {
     encodeAbiParameters,
     getTypesForEIP712Domain,
     hashTypedData,
+    isAddressEqual,
     validateTypedData
 } from "viem"
 
@@ -18,10 +19,11 @@ export async function signTypedData(
     }
 ): Promise<SignTypedDataReturnType> {
     const { admin, accountAddress, chainId, ...typedData } = parameters
+    const verifyingContract = (typedData.domain as TypedDataDomain)
+        ?.verifyingContract
     const isSelfVerifyingContract =
-        (
-            typedData.domain as TypedDataDomain
-        )?.verifyingContract?.toLowerCase() === accountAddress.toLowerCase()
+        !!verifyingContract &&
+        isAddressEqual(verifyingContract as Address, accountAddress)
 
     // If this is a self-verifying contract, we can use the admin's signature
     if (isSelfVerifyingContract) {

--- a/packages/permissionless/accounts/thirdweb/utils/signTypedData.ts
+++ b/packages/permissionless/accounts/thirdweb/utils/signTypedData.ts
@@ -21,7 +21,7 @@ export async function signTypedData(
     const isSelfVerifyingContract =
         (
             typedData.domain as TypedDataDomain
-        )?.verifyingContract?.toLowerCase() === accountAddress
+        )?.verifyingContract?.toLowerCase() === accountAddress.toLowerCase()
 
     // If this is a self-verifying contract, we can use the admin's signature
     if (isSelfVerifyingContract) {


### PR DESCRIPTION
Fixes a case-sensitive address comparison in the thirdweb `signTypedData` helper.

`verifyingContract` is lowercased before comparison, but `accountAddress` was compared as-is. If `accountAddress` contains checksum casing, self-verifying typed data can be misclassified and wrapped unnecessarily.

I could not run the project test suite locally because this checkout requires Bun workspace installation, and `bun` is not available in my environment.