### PR TITLE
Only strip dataSuffix hex prefix

### DIFF
--- a/packages/permissionless/actions/smartAccount/writeContract.test.ts
+++ b/packages/permissionless/actions/smartAccount/writeContract.test.ts
@@ -1,0 +1,45 @@
+import { encodeFunctionData } from "viem"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { sendTransaction } from "./sendTransaction.js"
+import { writeContract } from "./writeContract.js"
+
+vi.mock("./sendTransaction.js", () => ({
+    sendTransaction: vi.fn()
+}))
+
+const abi = [
+    {
+        type: "function",
+        name: "setBytes",
+        stateMutability: "nonpayable",
+        inputs: [{ name: "value", type: "bytes" }],
+        outputs: []
+    }
+] as const
+
+describe("writeContract", () => {
+    beforeEach(() => {
+        vi.mocked(sendTransaction).mockReset()
+        vi.mocked(sendTransaction).mockResolvedValue("0xhash")
+    })
+
+    test("only strips a 0x prefix from dataSuffix", async () => {
+        await writeContract(
+            {} as never,
+            {
+                abi,
+                address: "0x0000000000000000000000000000000000000001",
+                functionName: "setBytes",
+                args: ["0x"],
+                dataSuffix: "0x12340x5678"
+            } as never
+        )
+
+        expect(sendTransaction).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                data: `${encodeFunctionData({ abi, functionName: "setBytes", args: ["0x"] })}12340x5678`
+            })
+        )
+    })
+})

--- a/packages/permissionless/actions/smartAccount/writeContract.ts
+++ b/packages/permissionless/actions/smartAccount/writeContract.ts
@@ -58,7 +58,7 @@ export async function writeContract<
         sendTransaction<TAccount, undefined, undefined>,
         "sendTransaction"
     )({
-        data: `${data}${dataSuffix ? dataSuffix.replace("0x", "") : ""}`,
+        data: `${data}${dataSuffix ? dataSuffix.replace(/^0x/, "") : ""}`,
         to: address,
         ...request
     } as unknown as SendTransactionParameters<


### PR DESCRIPTION
## Summary

Only strips a leading `0x` from `dataSuffix` in `writeContract`.

## Why

`writeContract` appends `dataSuffix` to encoded calldata, but currently uses `dataSuffix.replace("0x", "")`. That removes the first `0x` anywhere in the suffix, not necessarily the hex prefix.

For example, a suffix like `12340x5678` would be changed to `12345678` even though it does not have a leading hex prefix.

## Change

- Uses `replace(/^0x/, "")` so only an actual prefix is stripped.
- Adds regression coverage for preserving an internal `0x` substring.
