### PR TITLE
Fix published package leaking raw .ts sources into consumer type-chec…

### DIFF
--- a/.changeset/brave-donuts-shine.md
+++ b/.changeset/brave-donuts-shine.md
@@ -1,0 +1,5 @@
+---
+"@pimlico/mock-paymaster": patch
+---
+
+Internal: paymaster lookups by entryPoint now go through a narrowing helper; the package compiles under `noUncheckedIndexedAccess`.

--- a/.changeset/tidy-moons-repair.md
+++ b/.changeset/tidy-moons-repair.md
@@ -1,0 +1,5 @@
+---
+"permissionless": patch
+---
+
+Fixed published-package type-checking for consumers on legacy `moduleResolution: "node"` (node10): every exported subpath directory now ships a proxy package.json pointing at the compiled `_types`/`_esm`/`_cjs` output, so `tsc` resolves declarations instead of pulling raw `.ts` sources into the consumer's program (#522). Barrel subpath modules (`actions/{erc7579,pimlico,passkeyServer,etherspot,smartAccount}` and `clients/{pimlico,passkeyServer}`) moved from single files into directories with index files — package-specifier imports are unaffected, only private deep imports of `_esm`/`_cjs`/`_types` file paths change. Test files and vitest config are no longer included in the npm tarball; `.ts` sources are still shipped for debuggability. The codebase now compiles under `noUncheckedIndexedAccess`, so sources stay error-free even when consumer projects type-check them with that flag enabled.

--- a/.changeset/wild-camels-check.md
+++ b/.changeset/wild-camels-check.md
@@ -1,0 +1,5 @@
+---
+"@permissionless/wagmi": patch
+---
+
+Fixed `useAvailableCapabilities` to return `undefined` instead of throwing when the connected chain has no capabilities entry, and hardened receipt handling in `useWaitForTransactionReceipt`. The package now compiles under `noUncheckedIndexedAccess`.

--- a/.github/fixtures/type-consumer/.gitignore
+++ b/.github/fixtures/type-consumer/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+*.tgz

--- a/.github/fixtures/type-consumer/consumer.ts
+++ b/.github/fixtures/type-consumer/consumer.ts
@@ -1,0 +1,27 @@
+// Imports every exported subpath of the permissionless package so that tsc
+// resolves each one. If raw .ts sources ever leak back into consumer programs
+// (missing subpath proxy package.json, see issue #522) or the published .d.ts
+// surface breaks under strict flags, these imports fail to type-check.
+export * as permissionless from "permissionless"
+export * as accounts from "permissionless/accounts"
+export * as accountsBiconomy from "permissionless/accounts/biconomy"
+export * as accountsEtherspot from "permissionless/accounts/etherspot"
+export * as accountsKernel from "permissionless/accounts/kernel"
+export * as accountsLight from "permissionless/accounts/light"
+export * as accountsNexus from "permissionless/accounts/nexus"
+export * as accountsSafe from "permissionless/accounts/safe"
+export * as accountsSimple from "permissionless/accounts/simple"
+export * as accountsThirdweb from "permissionless/accounts/thirdweb"
+export * as accountsTrust from "permissionless/accounts/trust"
+export * as actions from "permissionless/actions"
+export * as actionsErc7579 from "permissionless/actions/erc7579"
+export * as actionsEtherspot from "permissionless/actions/etherspot"
+export * as actionsPasskeyServer from "permissionless/actions/passkeyServer"
+export * as actionsPimlico from "permissionless/actions/pimlico"
+export * as actionsSmartAccount from "permissionless/actions/smartAccount"
+export * as clients from "permissionless/clients"
+export * as clientsPasskeyServer from "permissionless/clients/passkeyServer"
+export * as clientsPimlico from "permissionless/clients/pimlico"
+export * as errors from "permissionless/errors"
+export * as experimentalPimlico from "permissionless/experimental/pimlico"
+export * as utils from "permissionless/utils"

--- a/.github/fixtures/type-consumer/package.json
+++ b/.github/fixtures/type-consumer/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "type-consumer-fixture",
+    "private": true,
+    "description": "Type-checks the packed permissionless tarball the way consumers do (issue #522). The tarball is installed at CI time by the package-types workflow job.",
+    "devDependencies": {
+        "ox": "0.11.3",
+        "typescript": "5.9.3",
+        "viem": "2.51.3"
+    }
+}

--- a/.github/fixtures/type-consumer/tsconfig.bundler.json
+++ b/.github/fixtures/type-consumer/tsconfig.bundler.json
@@ -10,7 +10,11 @@
         "noUncheckedIndexedAccess": true,
         "exactOptionalPropertyTypes": true,
         "skipLibCheck": false,
-        "noEmit": true
+        "noEmit": true,
+        // Keep the program hermetic: without this, tsc auto-includes every
+        // node_modules/@types package from parent directories (the monorepo
+        // root), so unrelated workspace typings leak into this fixture.
+        "types": []
     },
     "files": ["consumer.ts"]
 }

--- a/.github/fixtures/type-consumer/tsconfig.bundler.json
+++ b/.github/fixtures/type-consumer/tsconfig.bundler.json
@@ -1,0 +1,16 @@
+{
+    // Modern resolution follows the exports map to the published .d.ts files.
+    // skipLibCheck is off and the strictest consumer flags are on, so this
+    // verifies the declaration surface stays clean for the pickiest setups.
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "skipLibCheck": false,
+        "noEmit": true
+    },
+    "files": ["consumer.ts"]
+}

--- a/.github/fixtures/type-consumer/tsconfig.node10.json
+++ b/.github/fixtures/type-consumer/tsconfig.node10.json
@@ -1,0 +1,18 @@
+{
+    // Legacy node10 resolution ignores the exports map for subpaths, so it
+    // only finds .d.ts declarations through the per-directory proxy
+    // package.json files. Raw .ts sources leaking into the program error out
+    // even with skipLibCheck enabled, which isolates the signal to exactly
+    // the regression this fixture guards against (issue #522).
+    "compilerOptions": {
+        "target": "ES2021",
+        "module": "commonjs",
+        "moduleResolution": "node10",
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "noEmit": true
+    },
+    "files": ["consumer.ts"]
+}

--- a/.github/fixtures/type-consumer/tsconfig.node10.json
+++ b/.github/fixtures/type-consumer/tsconfig.node10.json
@@ -12,7 +12,11 @@
         "noUncheckedIndexedAccess": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
-        "noEmit": true
+        "noEmit": true,
+        // Keep the program hermetic: without this, tsc auto-includes every
+        // node_modules/@types package from parent directories (the monorepo
+        // root), so unrelated workspace typings leak into this fixture.
+        "types": []
     },
     "files": ["consumer.ts"]
 }

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -46,6 +46,48 @@ jobs:
       - name: Build
         run: bun run build
 
+  package-types:
+    name: Package types (node10 + bundler consumers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Build permissionless
+        run: bun run build:permissionless:tsgo
+
+      - name: Pack tarball into fixture
+        working-directory: packages/permissionless
+        run: npm pack --pack-destination ../../.github/fixtures/type-consumer
+
+      - name: Install fixture dependencies
+        working-directory: .github/fixtures/type-consumer
+        run: |
+          npm install --no-package-lock
+          npm install --no-package-lock --no-save ./permissionless-*.tgz
+
+      - name: Type-check as a node10 consumer
+        working-directory: .github/fixtures/type-consumer
+        run: npx tsc -p tsconfig.node10.json
+
+      - name: Type-check as a bundler consumer
+        working-directory: .github/fixtures/type-consumer
+        run: npx tsc -p tsconfig.bundler.json
+
+      - name: Lint package publishing metadata (advisory)
+        working-directory: packages/permissionless
+        continue-on-error: true
+        run: npx --yes publint --strict
+
   docker-e2e:
     name: E2E-Coverage
     runs-on: ubuntu-latest

--- a/packages/mock-paymaster/relay.ts
+++ b/packages/mock-paymaster/relay.ts
@@ -181,6 +181,17 @@ const handleMethod = async ({
         [entryPoint08Address]: paymaster08
     }
 
+    const getPaymaster = (entryPoint: Address): Address => {
+        const paymaster = epToPaymaster[entryPoint]
+        if (paymaster === undefined) {
+            throw new RpcError(
+                "EntryPoint not supported",
+                ValidationErrors.InvalidFields
+            )
+        }
+        return paymaster
+    }
+
     if (parsedBody.method === "pm_sponsorUserOperation") {
         const params = pmSponsorUserOperationParamsSchema.safeParse(
             parsedBody.params
@@ -201,7 +212,7 @@ const handleMethod = async ({
             userOperation,
             paymasterMode: { mode: "verifying" },
             bundler: bundlerClient,
-            paymaster: epToPaymaster[entryPoint],
+            paymaster: getPaymaster(entryPoint),
             publicClient,
             paymasterSigner,
             estimateGas: true
@@ -242,7 +253,7 @@ const handleMethod = async ({
         return {
             ...getDummyPaymasterData({
                 is06,
-                paymaster: epToPaymaster[entryPoint],
+                paymaster: getPaymaster(entryPoint),
                 paymasterMode
             }),
             ...dummyPaymasterGas,
@@ -268,7 +279,7 @@ const handleMethod = async ({
             signer: paymasterSigner,
             userOp: userOperation as UserOperation,
             paymasterMode: getPaymasterMode(data),
-            paymaster: epToPaymaster[entryPoint],
+            paymaster: getPaymaster(entryPoint),
             publicClient
         })
     }

--- a/packages/permissionless/accounts/biconomy/package.json
+++ b/packages/permissionless/accounts/biconomy/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/accounts/biconomy/index.d.ts",
+    "module": "../../_esm/accounts/biconomy/index.js",
+    "main": "../../_cjs/accounts/biconomy/index.js"
+}

--- a/packages/permissionless/accounts/biconomy/toBiconomySmartAccount.ts
+++ b/packages/permissionless/accounts/biconomy/toBiconomySmartAccount.ts
@@ -288,11 +288,19 @@ export async function toBiconomySmartAccount(
                 const calls: { to: Address; value: bigint; data: Hex }[] = []
 
                 for (let i = 0; i < decoded.args[0].length; i++) {
-                    calls.push({
-                        to: decoded.args[0][i],
-                        value: decoded.args[1][i],
-                        data: decoded.args[2][i]
-                    })
+                    const to = decoded.args[0][i]
+                    const value = decoded.args[1][i]
+                    const data = decoded.args[2][i]
+
+                    if (
+                        to === undefined ||
+                        value === undefined ||
+                        data === undefined
+                    ) {
+                        throw new Error("Invalid batch call data")
+                    }
+
+                    calls.push({ to, value, data })
                 }
 
                 return calls

--- a/packages/permissionless/accounts/etherspot/package.json
+++ b/packages/permissionless/accounts/etherspot/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/accounts/etherspot/index.d.ts",
+    "module": "../../_esm/accounts/etherspot/index.js",
+    "main": "../../_cjs/accounts/etherspot/index.js"
+}

--- a/packages/permissionless/accounts/kernel/package.json
+++ b/packages/permissionless/accounts/kernel/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/accounts/kernel/index.d.ts",
+    "module": "../../_esm/accounts/kernel/index.js",
+    "main": "../../_cjs/accounts/kernel/index.js"
+}

--- a/packages/permissionless/accounts/kernel/toKernelSmartAccount.ts
+++ b/packages/permissionless/accounts/kernel/toKernelSmartAccount.ts
@@ -774,6 +774,13 @@ export async function toKernelSmartAccount<
                     ]
                 })
 
+                if (
+                    installFallbackCall === undefined ||
+                    uninstallFallbackCall === undefined
+                ) {
+                    throw new Error("Failed to encode fallback module calls")
+                }
+
                 const executeCallData = encodeCallData({
                     calls,
                     kernelVersion

--- a/packages/permissionless/accounts/light/package.json
+++ b/packages/permissionless/accounts/light/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/accounts/light/index.d.ts",
+    "module": "../../_esm/accounts/light/index.js",
+    "main": "../../_cjs/accounts/light/index.js"
+}

--- a/packages/permissionless/accounts/light/toLightSmartAccount.ts
+++ b/packages/permissionless/accounts/light/toLightSmartAccount.ts
@@ -355,11 +355,19 @@ export async function toLightSmartAccount<
                     }[] = []
 
                     for (let i = 0; i < decoded.args[0].length; i++) {
-                        calls.push({
-                            to: decoded.args[0][i],
-                            value: decoded.args[1][i],
-                            data: decoded.args[2][i]
-                        })
+                        const to = decoded.args[0][i]
+                        const value = decoded.args[1][i]
+                        const data = decoded.args[2][i]
+
+                        if (
+                            to === undefined ||
+                            value === undefined ||
+                            data === undefined
+                        ) {
+                            throw new Error("Invalid batch call data")
+                        }
+
+                        calls.push({ to, value, data })
                     }
 
                     return calls

--- a/packages/permissionless/accounts/nexus/package.json
+++ b/packages/permissionless/accounts/nexus/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/accounts/nexus/index.d.ts",
+    "module": "../../_esm/accounts/nexus/index.js",
+    "main": "../../_cjs/accounts/nexus/index.js"
+}

--- a/packages/permissionless/accounts/package.json
+++ b/packages/permissionless/accounts/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../_types/accounts/index.d.ts",
+    "module": "../_esm/accounts/index.js",
+    "main": "../_cjs/accounts/index.js"
+}

--- a/packages/permissionless/accounts/safe/package.json
+++ b/packages/permissionless/accounts/safe/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/accounts/safe/index.d.ts",
+    "module": "../../_esm/accounts/safe/index.js",
+    "main": "../../_cjs/accounts/safe/index.js"
+}

--- a/packages/permissionless/accounts/safe/signUserOperation.ts
+++ b/packages/permissionless/accounts/safe/signUserOperation.ts
@@ -97,6 +97,10 @@ export const getWebAuthnSignature = async ({
 
     const [, fields] = match
 
+    if (fields === undefined) {
+        throw new Error("challenge not found in client data JSON")
+    }
+
     return encodeAbiParameters(
         [
             { name: "authenticatorData", type: "bytes" },

--- a/packages/permissionless/accounts/safe/toSafeSmartAccount.ts
+++ b/packages/permissionless/accounts/safe/toSafeSmartAccount.ts
@@ -904,15 +904,17 @@ const getInitializerCode = async ({
         })
     }
 
-    if (!useMultiSendForSetup && multiCalls.length === 1) {
+    const firstMultiCall = multiCalls[0]
+
+    if (!useMultiSendForSetup && multiCalls.length === 1 && firstMultiCall) {
         return encodeFunctionData({
             abi: setupAbi,
             functionName: "setup",
             args: [
                 ownerAddresses,
                 threshold,
-                multiCalls[0].to,
-                multiCalls[0].data,
+                firstMultiCall.to,
+                firstMultiCall.data,
                 safe4337ModuleAddress,
                 paymentToken,
                 payment,

--- a/packages/permissionless/accounts/simple/package.json
+++ b/packages/permissionless/accounts/simple/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/accounts/simple/index.d.ts",
+    "module": "../../_esm/accounts/simple/index.js",
+    "main": "../../_cjs/accounts/simple/index.js"
+}

--- a/packages/permissionless/accounts/simple/toSimpleSmartAccount.ts
+++ b/packages/permissionless/accounts/simple/toSimpleSmartAccount.ts
@@ -374,11 +374,19 @@ export async function toSimpleSmartAccount<
                     const datas = decodedV7.args[2]
 
                     for (let i = 0; i < destinations.length; i++) {
-                        calls.push({
-                            to: destinations[i],
-                            data: datas[i],
-                            value: values[i]
-                        })
+                        const to = destinations[i]
+                        const data = datas[i]
+                        const value = values[i]
+
+                        if (
+                            to === undefined ||
+                            data === undefined ||
+                            value === undefined
+                        ) {
+                            throw new Error("Invalid batch call data")
+                        }
+
+                        calls.push({ to, data, value })
                     }
 
                     return calls
@@ -394,11 +402,14 @@ export async function toSimpleSmartAccount<
                     const datas = decodedV6.args[1]
 
                     for (let i = 0; i < destinations.length; i++) {
-                        calls.push({
-                            to: destinations[i],
-                            data: datas[i],
-                            value: 0n
-                        })
+                        const to = destinations[i]
+                        const data = datas[i]
+
+                        if (to === undefined || data === undefined) {
+                            throw new Error("Invalid batch call data")
+                        }
+
+                        calls.push({ to, data, value: 0n })
                     }
 
                     return calls

--- a/packages/permissionless/accounts/thirdweb/package.json
+++ b/packages/permissionless/accounts/thirdweb/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/accounts/thirdweb/index.d.ts",
+    "module": "../../_esm/accounts/thirdweb/index.js",
+    "main": "../../_cjs/accounts/thirdweb/index.js"
+}

--- a/packages/permissionless/accounts/thirdweb/utils/decodeCallData.ts
+++ b/packages/permissionless/accounts/thirdweb/utils/decodeCallData.ts
@@ -38,11 +38,15 @@ export const decodeCallData = async (callData: Hex) => {
         }[] = []
 
         for (let i = 0; i < decodedBatch.args[0].length; i++) {
-            calls.push({
-                to: decodedBatch.args[0][i],
-                value: decodedBatch.args[1][i],
-                data: decodedBatch.args[2][i]
-            })
+            const to = decodedBatch.args[0][i]
+            const value = decodedBatch.args[1][i]
+            const data = decodedBatch.args[2][i]
+
+            if (to === undefined || data === undefined) {
+                throw new Error("Invalid batch call data")
+            }
+
+            calls.push({ to, value, data })
         }
 
         return calls

--- a/packages/permissionless/accounts/trust/package.json
+++ b/packages/permissionless/accounts/trust/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/accounts/trust/index.d.ts",
+    "module": "../../_esm/accounts/trust/index.js",
+    "main": "../../_cjs/accounts/trust/index.js"
+}

--- a/packages/permissionless/accounts/trust/utils/decodeCallData.ts
+++ b/packages/permissionless/accounts/trust/utils/decodeCallData.ts
@@ -38,11 +38,15 @@ export const decodeCallData = async (callData: Hex) => {
         }[] = []
 
         for (let i = 0; i < decodedBatch.args[0].length; i++) {
-            calls.push({
-                to: decodedBatch.args[0][i],
-                value: decodedBatch.args[1][i],
-                data: decodedBatch.args[2][i]
-            })
+            const to = decodedBatch.args[0][i]
+            const value = decodedBatch.args[1][i]
+            const data = decodedBatch.args[2][i]
+
+            if (to === undefined || data === undefined) {
+                throw new Error("Invalid batch call data")
+            }
+
+            calls.push({ to, value, data })
         }
 
         return calls

--- a/packages/permissionless/actions/erc7579/index.ts
+++ b/packages/permissionless/actions/erc7579/index.ts
@@ -3,40 +3,34 @@ import type {
     GetSmartAccountParameter,
     SmartAccount
 } from "viem/account-abstraction"
-import { accountId } from "./erc7579/accountId.js"
-import {
-    type InstallModuleParameters,
-    installModule
-} from "./erc7579/installModule.js"
+import { accountId } from "./accountId.js"
+import { type InstallModuleParameters, installModule } from "./installModule.js"
 import {
     type InstallModulesParameters,
     installModules
-} from "./erc7579/installModules.js"
+} from "./installModules.js"
 import {
     type IsModuleInstalledParameters,
     isModuleInstalled
-} from "./erc7579/isModuleInstalled.js"
+} from "./isModuleInstalled.js"
 import {
     type SupportsExecutionModeParameters,
     supportsExecutionMode
-} from "./erc7579/supportsExecutionMode.js"
-import type {
-    CallType,
-    ExecutionMode
-} from "./erc7579/supportsExecutionMode.js"
+} from "./supportsExecutionMode.js"
+import type { CallType, ExecutionMode } from "./supportsExecutionMode.js"
 import {
     type SupportsModuleParameters,
     supportsModule
-} from "./erc7579/supportsModule.js"
-import type { ModuleType } from "./erc7579/supportsModule.js"
+} from "./supportsModule.js"
+import type { ModuleType } from "./supportsModule.js"
 import {
     type UninstallModuleParameters,
     uninstallModule
-} from "./erc7579/uninstallModule.js"
+} from "./uninstallModule.js"
 import {
     type UninstallModulesParameters,
     uninstallModules
-} from "./erc7579/uninstallModules.js"
+} from "./uninstallModules.js"
 
 export type Erc7579Actions<TSmartAccount extends SmartAccount | undefined> = {
     accountId: (

--- a/packages/permissionless/actions/erc7579/package.json
+++ b/packages/permissionless/actions/erc7579/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/actions/erc7579/index.d.ts",
+    "module": "../../_esm/actions/erc7579/index.js",
+    "main": "../../_cjs/actions/erc7579/index.js"
+}

--- a/packages/permissionless/actions/etherspot/index.ts
+++ b/packages/permissionless/actions/etherspot/index.ts
@@ -1,4 +1,4 @@
 export {
     type GetGasPriceResponseReturnType,
     getUserOperationGasPrice
-} from "./etherspot/getUserOperationGasPrice.js"
+} from "./getUserOperationGasPrice.js"

--- a/packages/permissionless/actions/etherspot/package.json
+++ b/packages/permissionless/actions/etherspot/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/actions/etherspot/index.d.ts",
+    "module": "../../_esm/actions/etherspot/index.js",
+    "main": "../../_cjs/actions/etherspot/index.js"
+}

--- a/packages/permissionless/actions/passkeyServer/index.ts
+++ b/packages/permissionless/actions/passkeyServer/index.ts
@@ -2,16 +2,16 @@ export {
     type StartRegistrationParameters,
     type StartRegistrationReturnType,
     startRegistration
-} from "./passkeyServer/startRegistration.js"
+} from "./startRegistration.js"
 
 export {
     type VerifyRegistrationParameters,
     type VerifyRegistrationReturnType,
     verifyRegistration
-} from "./passkeyServer/verifyRegistration.js"
+} from "./verifyRegistration.js"
 
 export {
     type GetCredentialsParameters,
     type GetCredentialsReturnType,
     getCredentials
-} from "./passkeyServer/getCredentials.js"
+} from "./getCredentials.js"

--- a/packages/permissionless/actions/passkeyServer/package.json
+++ b/packages/permissionless/actions/passkeyServer/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/actions/passkeyServer/index.d.ts",
+    "module": "../../_esm/actions/passkeyServer/index.js",
+    "main": "../../_cjs/actions/passkeyServer/index.js"
+}

--- a/packages/permissionless/actions/pimlico/estimateErc20PaymasterCost.ts
+++ b/packages/permissionless/actions/pimlico/estimateErc20PaymasterCost.ts
@@ -76,9 +76,15 @@ export const estimateErc20PaymasterCost = async <
         chain
     })
 
-    const postOpGas = quotes[0].postOpGas
-    const exchangeRate = quotes[0].exchangeRate
-    const exchangeRateNativeToUsd = quotes[0].exchangeRateNativeToUsd
+    const quote = quotes[0]
+
+    if (quote === undefined) {
+        throw new Error(`No token quote found for ${token}`)
+    }
+
+    const postOpGas = quote.postOpGas
+    const exchangeRate = quote.exchangeRate
+    const exchangeRateNativeToUsd = quote.exchangeRateNativeToUsd
 
     const userOperationMaxCost = getRequiredPrefund({
         userOperation,

--- a/packages/permissionless/actions/pimlico/index.ts
+++ b/packages/permissionless/actions/pimlico/index.ts
@@ -2,37 +2,37 @@ export {
     type GetTokenQuotesParameters,
     type GetTokenQuotesReturnType,
     getTokenQuotes
-} from "./pimlico/getTokenQuotes.js"
+} from "./getTokenQuotes.js"
 
 export {
     type GetUserOperationGasPriceReturnType,
     getUserOperationGasPrice
-} from "./pimlico/getUserOperationGasPrice.js"
+} from "./getUserOperationGasPrice.js"
 
 export {
     type GetUserOperationStatusParameters,
     type GetUserOperationStatusReturnType,
     getUserOperationStatus
-} from "./pimlico/getUserOperationStatus.js"
+} from "./getUserOperationStatus.js"
 
 export {
     type SendCompressedUserOperationParameters,
     sendCompressedUserOperation
-} from "./pimlico/sendCompressedUserOperation.js"
+} from "./sendCompressedUserOperation.js"
 
 export {
     type PimlicoSponsorUserOperationParameters,
     type SponsorUserOperationReturnType,
     sponsorUserOperation
-} from "./pimlico/sponsorUserOperation.js"
+} from "./sponsorUserOperation.js"
 
 export {
     type PimlicoActions,
     pimlicoActions
-} from "../clients/decorators/pimlico.js"
+} from "../../clients/decorators/pimlico.js"
 
 export {
     type ValidateSponsorshipPolicies,
     type ValidateSponsorshipPoliciesParameters,
     validateSponsorshipPolicies
-} from "./pimlico/validateSponsorshipPolicies.js"
+} from "./validateSponsorshipPolicies.js"

--- a/packages/permissionless/actions/pimlico/package.json
+++ b/packages/permissionless/actions/pimlico/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/actions/pimlico/index.d.ts",
+    "module": "../../_esm/actions/pimlico/index.js",
+    "main": "../../_cjs/actions/pimlico/index.js"
+}

--- a/packages/permissionless/actions/smartAccount.ts
+++ b/packages/permissionless/actions/smartAccount.ts
@@ -1,7 +1,0 @@
-export { sendTransaction } from "./smartAccount/sendTransaction.js"
-
-export { signMessage } from "./smartAccount/signMessage.js"
-
-export { signTypedData } from "./smartAccount/signTypedData.js"
-
-export { writeContract } from "./smartAccount/writeContract.js"

--- a/packages/permissionless/actions/smartAccount/index.ts
+++ b/packages/permissionless/actions/smartAccount/index.ts
@@ -1,0 +1,7 @@
+export { sendTransaction } from "./sendTransaction.js"
+
+export { signMessage } from "./signMessage.js"
+
+export { signTypedData } from "./signTypedData.js"
+
+export { writeContract } from "./writeContract.js"

--- a/packages/permissionless/actions/smartAccount/package.json
+++ b/packages/permissionless/actions/smartAccount/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/actions/smartAccount/index.d.ts",
+    "module": "../../_esm/actions/smartAccount/index.js",
+    "main": "../../_cjs/actions/smartAccount/index.js"
+}

--- a/packages/permissionless/clients/decorators/pimlico.ts
+++ b/packages/permissionless/clients/decorators/pimlico.ts
@@ -1,16 +1,6 @@
 import type { Address, Chain, Client, Hash, Prettify, Transport } from "viem"
 import type { EntryPointVersion } from "viem/account-abstraction"
 import {
-    type GetTokenQuotesParameters,
-    type GetTokenQuotesReturnType,
-    type SendCompressedUserOperationParameters,
-    type ValidateSponsorshipPolicies,
-    type ValidateSponsorshipPoliciesParameters,
-    getTokenQuotes,
-    sendCompressedUserOperation,
-    validateSponsorshipPolicies
-} from "../../actions/pimlico.js"
-import {
     type EstimateErc20PaymasterCostParameters,
     type EstimateErc20PaymasterCostReturnType,
     estimateErc20PaymasterCost
@@ -24,6 +14,16 @@ import {
     type GetUserOperationStatusReturnType,
     getUserOperationStatus
 } from "../../actions/pimlico/getUserOperationStatus.js"
+import {
+    type GetTokenQuotesParameters,
+    type GetTokenQuotesReturnType,
+    type SendCompressedUserOperationParameters,
+    type ValidateSponsorshipPolicies,
+    type ValidateSponsorshipPoliciesParameters,
+    getTokenQuotes,
+    sendCompressedUserOperation,
+    validateSponsorshipPolicies
+} from "../../actions/pimlico/index.js"
 import {
     type PimlicoSponsorUserOperationParameters,
     type SponsorUserOperationReturnType,

--- a/packages/permissionless/clients/package.json
+++ b/packages/permissionless/clients/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../_types/clients/index.d.ts",
+    "module": "../_esm/clients/index.js",
+    "main": "../_cjs/clients/index.js"
+}

--- a/packages/permissionless/clients/passkeyServer/index.ts
+++ b/packages/permissionless/clients/passkeyServer/index.ts
@@ -8,11 +8,11 @@ import type {
     Transport
 } from "viem"
 import { createClient } from "viem"
-import type { PasskeyServerRpcSchema } from "../types/passkeyServer.js"
+import type { PasskeyServerRpcSchema } from "../../types/passkeyServer.js"
 import {
     type PasskeyServerActions,
     passkeyServerActions
-} from "./decorators/passkeyServer.js"
+} from "../decorators/passkeyServer.js"
 
 export type PasskeyServerClient<
     rpcSchema extends RpcSchema | undefined = undefined

--- a/packages/permissionless/clients/passkeyServer/package.json
+++ b/packages/permissionless/clients/passkeyServer/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/clients/passkeyServer/index.d.ts",
+    "module": "../../_esm/clients/passkeyServer/index.js",
+    "main": "../../_cjs/clients/passkeyServer/index.js"
+}

--- a/packages/permissionless/clients/pimlico/index.ts
+++ b/packages/permissionless/clients/pimlico/index.ts
@@ -18,8 +18,8 @@ import {
     entryPoint07Address,
     paymasterActions
 } from "viem/account-abstraction"
-import type { PimlicoRpcSchema } from "../types/pimlico.js"
-import { type PimlicoActions, pimlicoActions } from "./decorators/pimlico.js"
+import type { PimlicoRpcSchema } from "../../types/pimlico.js"
+import { type PimlicoActions, pimlicoActions } from "../decorators/pimlico.js"
 
 export type PimlicoClient<
     entryPointVersion extends EntryPointVersion = EntryPointVersion,

--- a/packages/permissionless/clients/pimlico/package.json
+++ b/packages/permissionless/clients/pimlico/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/clients/pimlico/index.d.ts",
+    "module": "../../_esm/clients/pimlico/index.js",
+    "main": "../../_cjs/clients/pimlico/index.js"
+}

--- a/packages/permissionless/errors/package.json
+++ b/packages/permissionless/errors/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../_types/errors/index.d.ts",
+    "module": "../_esm/errors/index.js",
+    "main": "../_cjs/errors/index.js"
+}

--- a/packages/permissionless/experimental/pimlico/package.json
+++ b/packages/permissionless/experimental/pimlico/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../../_types/experimental/pimlico/index.d.ts",
+    "module": "../../_esm/experimental/pimlico/index.js",
+    "main": "../../_cjs/experimental/pimlico/index.js"
+}

--- a/packages/permissionless/experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.test.ts
+++ b/packages/permissionless/experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.test.ts
@@ -21,7 +21,7 @@ import {
     getPublicClient
 } from "../../../../permissionless-test/src/utils"
 import { createSmartAccountClient } from "../../../clients/createSmartAccountClient"
-import { createPimlicoClient } from "../../../clients/pimlico"
+import { createPimlicoClient } from "../../../clients/pimlico/index.js"
 import { prepareUserOperationForErc20Paymaster } from "./prepareUserOperationForErc20Paymaster"
 
 describe.each(getCoreSmartAccounts())(

--- a/packages/permissionless/experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.ts
+++ b/packages/permissionless/experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.ts
@@ -25,7 +25,7 @@ import {
 } from "viem/account-abstraction"
 import { getChainId as getChainId_, readContract } from "viem/actions"
 import { getAction, parseAccount } from "viem/utils"
-import { getTokenQuotes } from "../../../actions/pimlico.js"
+import { getTokenQuotes } from "../../../actions/pimlico/index.js"
 import { erc20BalanceOverride } from "../../../utils/erc20BalanceOverride.js"
 
 const MAINNET_USDT_ADDRESS = getAddress(
@@ -111,7 +111,9 @@ export const prepareUserOperationForErc20Paymaster =
                 entryPointAddress: account.entryPoint.address
             })
 
-            if (quotes.length === 0) {
+            const quote = quotes[0]
+
+            if (quote === undefined) {
                 throw new RpcError(new Error("Quotes not found"), {
                     shortMessage:
                         "client didn't return token quotes, check if the token is supported"
@@ -122,7 +124,7 @@ export const prepareUserOperationForErc20Paymaster =
                 postOpGas,
                 exchangeRate,
                 paymaster: paymasterERC20Address
-            } = quotes[0]
+            } = quote
 
             let calls = parameters.calls
 
@@ -155,7 +157,7 @@ export const prepareUserOperationForErc20Paymaster =
             // Call prepareUserOperation
             ////////////////////////////////////////////////////////////////////////////////
 
-            const balanceSlot = _balanceSlot ?? quotes[0].balanceSlot
+            const balanceSlot = _balanceSlot ?? quote.balanceSlot
             const hasBalanceSlot = balanceSlot !== undefined
 
             if (!hasBalanceSlot && balanceOverride) {

--- a/packages/permissionless/package.json
+++ b/packages/permissionless/package.json
@@ -11,14 +11,19 @@
     "type": "module",
     "sideEffects": false,
     "description": "A utility library for working with ERC-4337",
-    "keywords": [
-        "ethereum",
-        "erc-4337",
-        "eip-4337",
-        "paymaster",
-        "bundler"
-    ],
+    "keywords": ["ethereum", "erc-4337", "eip-4337", "paymaster", "bundler"],
     "license": "MIT",
+    "files": [
+        "*",
+        "!**/*.test.ts",
+        "!**/*.test.ts.snap",
+        "!**/*.test-d.ts",
+        "!**/*.bench.ts",
+        "!**/setupTests.ts",
+        "!**/*.tsbuildinfo",
+        "!vitest.config.ts",
+        "!coverage"
+    ],
     "exports": {
         ".": {
             "types": "./_types/index.d.ts",
@@ -81,29 +86,29 @@
             "default": "./_cjs/actions/index.js"
         },
         "./actions/erc7579": {
-            "types": "./_types/actions/erc7579.d.ts",
-            "import": "./_esm/actions/erc7579.js",
-            "default": "./_cjs/actions/erc7579.js"
+            "types": "./_types/actions/erc7579/index.d.ts",
+            "import": "./_esm/actions/erc7579/index.js",
+            "default": "./_cjs/actions/erc7579/index.js"
         },
         "./actions/pimlico": {
-            "types": "./_types/actions/pimlico.d.ts",
-            "import": "./_esm/actions/pimlico.js",
-            "default": "./_cjs/actions/pimlico.js"
+            "types": "./_types/actions/pimlico/index.d.ts",
+            "import": "./_esm/actions/pimlico/index.js",
+            "default": "./_cjs/actions/pimlico/index.js"
         },
         "./actions/passkeyServer": {
-            "types": "./_types/actions/passkeyServer.d.ts",
-            "import": "./_esm/actions/passkeyServer.js",
-            "default": "./_cjs/actions/passkeyServer.js"
+            "types": "./_types/actions/passkeyServer/index.d.ts",
+            "import": "./_esm/actions/passkeyServer/index.js",
+            "default": "./_cjs/actions/passkeyServer/index.js"
         },
         "./actions/etherspot": {
-            "types": "./_types/actions/etherspot.d.ts",
-            "import": "./_esm/actions/etherspot.js",
-            "default": "./_cjs/actions/etherspot.js"
+            "types": "./_types/actions/etherspot/index.d.ts",
+            "import": "./_esm/actions/etherspot/index.js",
+            "default": "./_cjs/actions/etherspot/index.js"
         },
         "./actions/smartAccount": {
-            "types": "./_types/actions/smartAccount.d.ts",
-            "import": "./_esm/actions/smartAccount.js",
-            "default": "./_cjs/actions/smartAccount.js"
+            "types": "./_types/actions/smartAccount/index.d.ts",
+            "import": "./_esm/actions/smartAccount/index.js",
+            "default": "./_cjs/actions/smartAccount/index.js"
         },
         "./clients": {
             "types": "./_types/clients/index.d.ts",
@@ -111,14 +116,14 @@
             "default": "./_cjs/clients/index.js"
         },
         "./clients/pimlico": {
-            "types": "./_types/clients/pimlico.d.ts",
-            "import": "./_esm/clients/pimlico.js",
-            "default": "./_cjs/clients/pimlico.js"
+            "types": "./_types/clients/pimlico/index.d.ts",
+            "import": "./_esm/clients/pimlico/index.js",
+            "default": "./_cjs/clients/pimlico/index.js"
         },
         "./clients/passkeyServer": {
-            "types": "./_types/clients/passkeyServer.d.ts",
-            "import": "./_esm/clients/passkeyServer.js",
-            "default": "./_cjs/clients/passkeyServer.js"
+            "types": "./_types/clients/passkeyServer/index.d.ts",
+            "import": "./_esm/clients/passkeyServer/index.js",
+            "default": "./_cjs/clients/passkeyServer/index.js"
         },
         "./utils": {
             "types": "./_types/utils/index.d.ts",

--- a/packages/permissionless/types/package.json
+++ b/packages/permissionless/types/package.json
@@ -1,6 +1,0 @@
-{
-    "type": "module",
-    "types": "../_types/types/index.d.ts",
-    "module": "../_esm/types/index.js",
-    "main": "../_cjs/types/index.js"
-}

--- a/packages/permissionless/utils/package.json
+++ b/packages/permissionless/utils/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "types": "../_types/utils/index.d.ts",
+    "module": "../_esm/utils/index.js",
+    "main": "../_cjs/utils/index.js"
+}

--- a/packages/wagmi/hooks/useAvailableCapabilities.ts
+++ b/packages/wagmi/hooks/useAvailableCapabilities.ts
@@ -20,6 +20,7 @@ export const useAvailableCapabilities = () => {
     const memoisedCapabilities = useMemo(() => {
         if (!availableCapabilities || !account.chainId) return undefined
         const capabilitiesForChain = availableCapabilities[account.chainId]
+        if (capabilitiesForChain === undefined) return undefined
         if (capabilitiesConfigured === undefined) return undefined
 
         let capabilities: WalletSendCallsParameters<WalletCapabilities>[number]["capabilities"] =

--- a/packages/wagmi/hooks/useWaitForTransactionReceipt.ts
+++ b/packages/wagmi/hooks/useWaitForTransactionReceipt.ts
@@ -222,11 +222,7 @@ export async function waitForCallsStatus<
                             )
                                 return
 
-                            if (receipt.receipts?.length === 0) {
-                                return
-                            }
-
-                            const finalReceipt = receipt.receipts
+                            const finalReceipt = receipt.receipts?.[0]
 
                             if (!finalReceipt) {
                                 return
@@ -236,7 +232,7 @@ export async function waitForCallsStatus<
                                 client,
                                 getTransactionReceipt,
                                 "getTransactionReceipt"
-                            )({ hash: finalReceipt[0].transactionHash })
+                            )({ hash: finalReceipt.transactionHash })
 
                             done(() =>
                                 emit.resolve({
@@ -272,11 +268,7 @@ export async function waitForCallsStatus<
                         )
                             return
 
-                        if (receipt.receipts?.length === 0) {
-                            return
-                        }
-
-                        const finalReceipt = receipt.receipts
+                        const finalReceipt = receipt.receipts?.[0]
 
                         if (!finalReceipt) {
                             return
@@ -286,7 +278,7 @@ export async function waitForCallsStatus<
                             client,
                             getTransactionReceipt,
                             "getTransactionReceipt"
-                        )({ hash: finalReceipt[0].transactionHash })
+                        )({ hash: finalReceipt.transactionHash })
 
                         done(() =>
                             emit.resolve({

--- a/tsconfig/tsconfig.base.json
+++ b/tsconfig/tsconfig.base.json
@@ -13,9 +13,9 @@
         "noImplicitOverride": true, // Not enabled by default in `strict` mode.
         "noUnusedLocals": true, // Not enabled by default in `strict` mode.
         "noUnusedParameters": true, // Not enabled by default in `strict` mode.
-        // TODO: The following options are also not enabled by default in `strict` mode and would be nice to have but would require some adjustments to the codebase.
+        // TODO: `exactOptionalPropertyTypes` is also not enabled by default in `strict` mode and would be nice to have but would require some adjustments to the codebase.
         // "exactOptionalPropertyTypes": true,
-        // "noUncheckedIndexedAccess": true,
+        "noUncheckedIndexedAccess": true, // Not enabled by default in `strict` mode. Keeps published sources clean for consumers who type-check them with this flag (see issue #522).
         // JavaScript support
         "allowJs": false,
         "checkJs": false,


### PR DESCRIPTION
…ks (#522)

Consumers on legacy moduleResolution "node" (node10) resolved subpath imports like permissionless/accounts to raw .ts sources instead of the compiled declarations, because node10 ignores the exports map and prefers .ts over .d.ts in directory lookups. The sources then got type-checked with the consumer's own compiler flags, surfacing errors under flags stricter than the library's build (noUncheckedIndexedAccess).

- Ship a proxy package.json in every exported subpath directory (viem parity; the pattern existed for actions/ but was never completed), redirecting node10 resolution to _types/_esm/_cjs
- Move the 7 file-based barrel subpaths (actions/{erc7579,pimlico, passkeyServer,etherspot,smartAccount}, clients/{pimlico, passkeyServer}) into directories, since a .ts file beats a directory proxy under node10; package-specifier imports are unaffected
- Exclude test files, vitest config, and coverage from the tarball via a files field; raw .ts sources are intentionally kept for debugging
- Enable noUncheckedIndexedAccess and fix the resulting errors across permissionless, wagmi, and mock-paymaster so shipped sources stay clean even when consumers type-check them with that flag
- Add a package-types CI job that packs the tarball and type-checks it as node10 and bundler consumers to prevent regressions
- Delete the broken types/package.json proxy (pointed at a nonexistent declaration file; ./types was never exported)