### PR TITLE
Fix ~80s consumer type-checks of client aliases (#500)

### DIFF
--- a/.changeset/heavy-planes-shave.md
+++ b/.changeset/heavy-planes-shave.md
@@ -1,0 +1,5 @@
+---
+"permissionless": patch
+---
+
+Fixed extreme TypeScript type-checking slowness (~80s per call site, issue #500) when a client created by `createSmartAccountClient`, `createPimlicoClient`, or `createPasskeyServerClient` is checked against the bare `SmartAccountClient` / `PimlicoClient` / `PasskeyServerClient` alias (e.g. `useQuery<SmartAccountClient>`). The client type aliases now use an inline mapped-type body with variance annotations (the same pattern viem ships in `SimulateContractReturnType`, wevm/viem#2557) so TypeScript compares instantiations argument-by-argument instead of expanding the full action surface structurally. Return-type precision is unchanged.

--- a/.github/fixtures/type-consumer/issue-500.ts
+++ b/.github/fixtures/type-consumer/issue-500.ts
@@ -1,0 +1,120 @@
+// Guards for issue #500: createSmartAccountClient's precise return type must
+// stay assignable to the bare SmartAccountClient alias cheaply (variance fast
+// path) WITHOUT the fix widening the return type. The Equal assertions fail if
+// the return type ever collapses to the loose defaults (or any) — which is
+// what the rejected fix in PR #511 would have done — and the bare-alias
+// assignments fail if the variance restructure ever rejects something the old
+// structural check accepted.
+import {
+    type SmartAccountClient,
+    createSmartAccountClient
+} from "permissionless"
+import {
+    type ToSimpleSmartAccountReturnType,
+    toSimpleSmartAccount
+} from "permissionless/accounts"
+import {
+    type PasskeyServerClient,
+    createPasskeyServerClient
+} from "permissionless/clients/passkeyServer"
+import {
+    type PimlicoClient,
+    createPimlicoClient
+} from "permissionless/clients/pimlico"
+import {
+    http,
+    type Transport,
+    type createClient,
+    createPublicClient
+} from "viem"
+import { entryPoint07Address } from "viem/account-abstraction"
+import { privateKeyToAccount } from "viem/accounts"
+import { sepolia } from "viem/chains"
+
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
+    ? 1
+    : 2
+    ? true
+    : false
+type Expect<T extends true> = T
+
+const publicClient = createPublicClient({
+    chain: sepolia,
+    transport: http("https://rpc.invalid")
+})
+
+const pimlicoClient = createPimlicoClient({
+    transport: http("https://bundler.invalid"),
+    entryPoint: { address: entryPoint07Address, version: "0.7" }
+})
+
+export async function makeClient() {
+    const account = await toSimpleSmartAccount({
+        client: publicClient,
+        owner: privateKeyToAccount(`0x${"11".repeat(32)}` as `0x${string}`),
+        entryPoint: { address: entryPoint07Address, version: "0.7" }
+    })
+
+    return createSmartAccountClient({
+        account,
+        chain: sepolia,
+        bundlerTransport: http("https://bundler.invalid"),
+        paymaster: pimlicoClient,
+        userOperation: {
+            estimateFeesPerGas: async () =>
+                (await pimlicoClient.getUserOperationGasPrice()).fast
+        }
+    })
+}
+
+type PreciseClient = Awaited<ReturnType<typeof makeClient>>
+declare const precise: PreciseClient
+
+// The #500 hot path: precise instantiation → bare alias.
+export const bare: SmartAccountClient = precise
+
+// Return-type precision is unchanged — everything PR #511 would have widened.
+export type AccountIsExact = Expect<
+    Equal<PreciseClient["account"], ToSimpleSmartAccountReturnType<"0.7">>
+>
+export type ChainIsExact = Expect<Equal<PreciseClient["chain"], typeof sepolia>>
+export type ClientSlotIsExact = Expect<
+    Equal<PreciseClient["client"], undefined>
+>
+
+// A custom rpcSchema must still assign to the bare alias. Its type argument
+// differs from the bare default (`undefined`), so the variance fast path
+// cannot decide this pairwise — it must fall back to the structural check.
+// This line breaks loudly if `rpcSchema` ever gets a variance annotation (or
+// a future TypeScript starts measuring it) in a way that hard-rejects first.
+type CustomRpcSchema = [
+    { Method: "custom_method"; Parameters: [value: string]; ReturnType: string }
+]
+declare const withCustomSchema: SmartAccountClient<
+    Transport,
+    typeof sepolia,
+    ToSimpleSmartAccountReturnType<"0.7">,
+    undefined,
+    CustomRpcSchema
+>
+export const bareFromCustomSchema: SmartAccountClient = withCustomSchema
+
+// Same guarantees for PimlicoClient (fixed alongside, identical pathology).
+export const barePimlico: PimlicoClient = pimlicoClient
+export type PimlicoChainIsExact = Expect<
+    Equal<(typeof pimlicoClient)["chain"], undefined>
+>
+
+// Same guarantees for PasskeyServerClient (same inline-mapped restructure).
+const passkeyClient = createPasskeyServerClient({
+    transport: http("https://passkeys.invalid")
+})
+export const barePasskey: PasskeyServerClient = passkeyClient
+declare const passkeyWithCustomSchema: PasskeyServerClient<CustomRpcSchema>
+export const barePasskeyFromCustomSchema: PasskeyServerClient =
+    passkeyWithCustomSchema
+
+// The precise client still satisfies structural consumers that were never
+// spelled as the alias (no aliasSymbol on either side → structural path).
+declare const plainViemClient: ReturnType<typeof createClient>
+export const clientSlotAccepts: SmartAccountClient["client"] = plainViemClient

--- a/.github/fixtures/type-consumer/tsconfig.bundler.json
+++ b/.github/fixtures/type-consumer/tsconfig.bundler.json
@@ -16,5 +16,5 @@
         // root), so unrelated workspace typings leak into this fixture.
         "types": []
     },
-    "files": ["consumer.ts"]
+    "files": ["consumer.ts", "issue-500.ts"]
 }

--- a/.github/fixtures/type-consumer/tsconfig.node10.json
+++ b/.github/fixtures/type-consumer/tsconfig.node10.json
@@ -18,5 +18,9 @@
         // root), so unrelated workspace typings leak into this fixture.
         "types": []
     },
+    // issue-500.ts is checked only by tsconfig.bundler.json: its direct viem
+    // value imports (viem/accounts, viem/chains) make node10 resolution pull
+    // raw .ts sources out of viem's nested ox install — a fixture dependency
+    // quirk unrelated to what either file guards.
     "files": ["consumer.ts"]
 }

--- a/packages/permissionless/clients/createSmartAccountClient.ts
+++ b/packages/permissionless/clients/createSmartAccountClient.ts
@@ -29,31 +29,56 @@ import {
  *  - Add docs
  *  - Fix typing, 'accounts' is required to signMessage, signTypedData, signTransaction, but not needed here, since account is embedded in the client
  */
-export type SmartAccountClient<
-    transport extends Transport = Transport,
-    chain extends Chain | undefined = Chain | undefined,
-    account extends SmartAccount | undefined = SmartAccount | undefined,
-    client extends Client | undefined = Client | undefined,
-    rpcSchema extends RpcSchema | undefined = undefined
-> = Prettify<
-    Client<
-        transport,
-        chain extends Chain
-            ? chain
-            : client extends Client<any, infer chain>
-              ? chain
-              : undefined,
-        account,
-        rpcSchema extends RpcSchema
-            ? [...BundlerRpcSchema, ...rpcSchema]
-            : BundlerRpcSchema,
-        BundlerActions<account> & SmartAccountActions<chain, account>
-    >
+type SmartAccountClientInner<
+    transport extends Transport,
+    chain extends Chain | undefined,
+    account extends SmartAccount | undefined,
+    client extends Client | undefined,
+    rpcSchema extends RpcSchema | undefined
+> = Client<
+    transport,
+    chain extends Chain
+        ? chain
+        : // biome-ignore lint/suspicious/noExplicitAny: We need any to infer the chain type
+          client extends Client<any, infer chain>
+          ? chain
+          : undefined,
+    account,
+    rpcSchema extends RpcSchema
+        ? [...BundlerRpcSchema, ...rpcSchema]
+        : BundlerRpcSchema,
+    BundlerActions<account> & SmartAccountActions<chain, account>
 > & {
     client: client
     paymaster: BundlerClientConfig["paymaster"] | undefined
     paymasterContext: BundlerClientConfig["paymasterContext"] | undefined
     userOperation: BundlerClientConfig["userOperation"] | undefined
+}
+
+// Variance annotations referred from viem:
+// https://github.com/wevm/viem/blob/main/src/actions/public/simulateContract.ts#L129
+export type SmartAccountClient<
+    out transport extends Transport = Transport,
+    /** @ts-expect-error cast variance */
+    out chain extends Chain | undefined = Chain | undefined,
+    /** @ts-expect-error cast variance */
+    out account extends SmartAccount | undefined = SmartAccount | undefined,
+    out client extends Client | undefined = Client | undefined,
+    rpcSchema extends RpcSchema | undefined = undefined
+> = {
+    [key in keyof SmartAccountClientInner<
+        transport,
+        chain,
+        account,
+        client,
+        rpcSchema
+    >]: SmartAccountClientInner<
+        transport,
+        chain,
+        account,
+        client,
+        rpcSchema
+    >[key]
 }
 
 export type SmartAccountClientConfig<

--- a/packages/permissionless/clients/passkeyServer/index.ts
+++ b/packages/permissionless/clients/passkeyServer/index.ts
@@ -14,19 +14,21 @@ import {
     passkeyServerActions
 } from "../decorators/passkeyServer.js"
 
+type PasskeyServerClientInner<rpcSchema extends RpcSchema | undefined> = Client<
+    Transport,
+    Chain | undefined,
+    Account | undefined,
+    rpcSchema extends RpcSchema
+        ? [...PasskeyServerRpcSchema, ...rpcSchema]
+        : [...PasskeyServerRpcSchema],
+    PasskeyServerActions
+>
+
 export type PasskeyServerClient<
     rpcSchema extends RpcSchema | undefined = undefined
-> = Prettify<
-    Client<
-        Transport,
-        Chain | undefined,
-        Account | undefined,
-        rpcSchema extends RpcSchema
-            ? [...PasskeyServerRpcSchema, ...rpcSchema]
-            : [...PasskeyServerRpcSchema],
-        PasskeyServerActions
-    >
->
+> = {
+    [key in keyof PasskeyServerClientInner<rpcSchema>]: PasskeyServerClientInner<rpcSchema>[key]
+}
 
 export type PasskeyServerClientConfig<
     rpcSchema extends RpcSchema | undefined = undefined

--- a/packages/permissionless/clients/pimlico/index.ts
+++ b/packages/permissionless/clients/pimlico/index.ts
@@ -21,31 +21,58 @@ import {
 import type { PimlicoRpcSchema } from "../../types/pimlico.js"
 import { type PimlicoActions, pimlicoActions } from "../decorators/pimlico.js"
 
-export type PimlicoClient<
-    entryPointVersion extends EntryPointVersion = EntryPointVersion,
-    transport extends Transport = Transport,
-    chain extends Chain | undefined = Chain | undefined,
-    account extends SmartAccount | undefined = SmartAccount | undefined,
-    client extends Client | undefined = Client | undefined,
-    rpcSchema extends RpcSchema | undefined = undefined
-> = Prettify<
-    Client<
-        transport,
-        chain extends Chain
-            ? chain
-            : // biome-ignore lint/suspicious/noExplicitAny: We need any to infer the chain type
-              client extends Client<any, infer chain>
-              ? chain
-              : undefined,
-        account,
-        rpcSchema extends RpcSchema
-            ? [...BundlerRpcSchema, ...PimlicoRpcSchema, ...rpcSchema]
-            : [...BundlerRpcSchema, ...PimlicoRpcSchema],
-        BundlerActions<account> &
-            PaymasterActions &
-            PimlicoActions<chain, entryPointVersion>
-    >
+type PimlicoClientInner<
+    entryPointVersion extends EntryPointVersion,
+    transport extends Transport,
+    chain extends Chain | undefined,
+    account extends SmartAccount | undefined,
+    client extends Client | undefined,
+    rpcSchema extends RpcSchema | undefined
+> = Client<
+    transport,
+    chain extends Chain
+        ? chain
+        : // biome-ignore lint/suspicious/noExplicitAny: We need any to infer the chain type
+          client extends Client<any, infer chain>
+          ? chain
+          : undefined,
+    account,
+    rpcSchema extends RpcSchema
+        ? [...BundlerRpcSchema, ...PimlicoRpcSchema, ...rpcSchema]
+        : [...BundlerRpcSchema, ...PimlicoRpcSchema],
+    BundlerActions<account> &
+        PaymasterActions &
+        PimlicoActions<chain, entryPointVersion>
 >
+
+// Variance annotations referred from viem:
+// https://github.com/wevm/viem/blob/main/src/actions/public/simulateContract.ts#L129
+export type PimlicoClient<
+    /** @ts-expect-error cast variance */
+    out entryPointVersion extends EntryPointVersion = EntryPointVersion,
+    out transport extends Transport = Transport,
+    /** @ts-expect-error cast variance */
+    out chain extends Chain | undefined = Chain | undefined,
+    out account extends SmartAccount | undefined = SmartAccount | undefined,
+    out client extends Client | undefined = Client | undefined,
+    rpcSchema extends RpcSchema | undefined = undefined
+> = {
+    [key in keyof PimlicoClientInner<
+        entryPointVersion,
+        transport,
+        chain,
+        account,
+        client,
+        rpcSchema
+    >]: PimlicoClientInner<
+        entryPointVersion,
+        transport,
+        chain,
+        account,
+        client,
+        rpcSchema
+    >[key]
+}
 
 export type PimlicoClientConfig<
     entryPointVersion extends EntryPointVersion = EntryPointVersion,


### PR DESCRIPTION
Checking a client created by createSmartAccountClient, createPimlicoClient, or createPasskeyServerClient against its bare alias (e.g. useQuery<SmartAccountClient>) forced TypeScript to structurally expand the full action surface on every call site: ~82s / 481k type instantiations in the issue's reproduction.

The client aliases now use an inline mapped-type body over a private *Inner alias, with variance annotations on the type parameters (the same pattern viem ships in SimulateContractReturnType, wevm/viem#2557). Both sides of a comparison then carry the alias's identity, so tsc compares instantiations argument-by-argument instead of expanding them: the issue's repro drops to 0.44s / 149k instantiations. rpcSchema is deliberately left unannotated so a pairwise mismatch falls back to the structural check rather than rejecting assignments that compile today. Return-type precision is unchanged.

The mapped types must stay inline: extracting them into a shared helper (e.g. Flatten<T>) re-attaches the helper's alias identity instead and restores the slowdown (measured: 444k instantiations, no improvement).

The type-consumer fixture now guards all of this against the packed tarball: Equal-assertions that account/chain/client stay exactly inferred (what PR #511 would have widened), bare-alias assignability (which fails loudly if the variance fast path ever hard-rejects), and custom-rpcSchema fallback for all three clients.

Closes https://github.com/pimlicolabs/permissionless.js/issues/500.