### PR TITLE
fix: wait for deploy tx receipts in e2e setup to fix registry race

### DIFF
--- a/packages/permissionless-test/mock-aa-infra/alto/index.ts
+++ b/packages/permissionless-test/mock-aa-infra/alto/index.ts
@@ -129,7 +129,7 @@ export const setupContracts = async (rpc: string) => {
         bytecode: SAFE_SINGLETON_FACTORY_BYTECODE
     })
 
-    await Promise.all([
+    const deployHashes = await Promise.all([
         walletClient.sendTransaction({
             to: DETERMINISTIC_DEPLOYER,
             data: ENTRY_POINT_V08_CREATECALL,
@@ -552,6 +552,12 @@ export const setupContracts = async (rpc: string) => {
             nonce: nonce++
         })
     ])
+
+    await Promise.all(
+        deployHashes.map((hash) =>
+            client.waitForTransactionReceipt({ hash, pollingInterval: 50 })
+        )
+    )
 
     const rhinestoneAttester = "0x000000333034E9f539ce08819E12c1b8Cb29084d"
     await anvilClient.setBalance({


### PR DESCRIPTION
## Problem

E2E failed twice on #530 (and can flake on any PR) with:

```
execution reverted: custom error 0xf184406b: dbca873b…
```

`0xf184406b` decodes to `InvalidResolverUID(bytes32)` from the Rhinestone ERC-7579 registry, thrown while `setupContracts` deploys the test module — before any test logic runs. A different random test file failed on each attempt (`getTokenQuotes`, `getSenderAddress`): whichever vitest worker's rig lost the race.

## Root cause

`setupContracts` sends 68 deploy txs from account 0 in one `Promise.all` with manually incremented nonces and no receipt waits. Anvil mines a tx synchronously only if its nonce is next; txs arriving out of nonce order are queued and mined asynchronously later. `Promise.all` resolving therefore doesn't mean the deploys are mined.

In the failing run the `deployModule` gas estimate was built with account nonce **41** while **68** txs had been sent — 27 deploys (including the registry, which sits late in the batch) were still queued. The impersonated `registerSchema`/`registerResolver` txs no-op'd against the then-empty registry address, so when the registry finally deployed, `deployModule` found no resolver record → `InvalidResolverUID`.

## Fix

Capture the 68 tx hashes and `waitForTransactionReceipt` on all of them before the registry/kernel setup sections. Adds ~no time when there's no queue backlog (local run of a previously-failing file: setup + tests in ~2s).

Once this merges, the changesets bot regenerates #530 and its CI re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)