### PR TITLE
fix: grant pull-requests write to release job for version PR updates

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -43,6 +43,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
## Problem

Every `Main` workflow run with pending changesets ends red: the `Release` job fails with

```
GraphqlResponseError: Resource not accessible by integration
```

right after `updating found pull request #530` (same failure signature on the July release runs).

## Root cause

When changesets are pending, `changesets/action` runs in version-PR mode in **both** jobs — and updating the PR title/body via GraphQL requires the `pull-requests: write` token scope.

- The `changesets` job has no `permissions:` block, so it inherits the repo default (`write` on everything) → succeeds.
- The `release` job declares an explicit block with only `id-token: write` + `contents: write`. An explicit block sets every unlisted scope to `none`, so its token has `pull-requests: none` → the PR update fails.

## Fix

Add `pull-requests: write` to the `release` job's permissions. No repo settings or branch protection changes needed — `default_workflow_permissions` is already `write` and `can_approve_pull_request_reviews` is already enabled.

Publishing on merge of the version PR is unaffected and already works (post-merge run on July 9: `Release` succeeded and published; only the pre-merge PR-update path fails today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)