### PR TITLE
test: coverage accounting + gaps + codecov threshold (78.4% → 69.9% regression)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # the 1.0 accounting regression was −8.57 %; 1 % fails a real drop
+        # without tripping on run-to-run noise in the e2e rig.
+        threshold: 1%
+
+comment:
+  behavior: default

--- a/docs/testing/06-ci-and-running.md
+++ b/docs/testing/06-ci-and-running.md
@@ -49,14 +49,14 @@ jobs:
       - run: bun run build
       - run: echo "VITE_FORK_RPC_URL=${{ secrets.VITE_FORK_RPC_URL }}" > .env.test
       - run: bun run test:ci
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
 ```
 
 Key points:
 
 - **Node 22.2.0** is used in CI; local dev with a different Node should match this for parity.
 - `.env.test` is **generated in-workflow** with `VITE_FORK_RPC_URL` from a GitHub secret. When the secret is unset, the value is empty and `setupContracts` runs normally. When set, Anvil forks that URL and `setupContracts` is skipped ([see fork mode](#fork-mode)).
-- Coverage is uploaded to Codecov via `codecov-action@v3`.
+- Coverage is uploaded to Codecov via `codecov-action@v5`, gated by `codecov.yml` at the repo root ([see below](#coverage-accounting)).
 - Timeout: 60 minutes.
 
 ### The disabled sharded test job
@@ -73,6 +73,40 @@ Loaded by Vitest via `loadEnv("test", process.cwd())` (`vitest.config.ts:29`), w
 | `CI`                     | `vitest.config.ts:10`                        | Switches coverage reporter to `lcov` only.                                               |
 
 Other `VITE_*` vars (`VITE_ANVIL_BLOCK_NUMBER`, `VITE_ANVIL_BLOCK_TIME`, `VITE_NETWORK_TRANSPORT_MODE`, `VITE_BATCH_MULTICALL`, `VITE_ANVIL_FORK_URL`) appear in `verify.yml` but are only consumed by the disabled sharded job. They have no effect in the active `testWithRpc` fixture.
+
+## Coverage accounting
+
+`--coverage` runs the v8 provider with `all: true`, so every file matched by
+`coverage.include` (`**/permissionless/**`) counts, whether a test touched it or
+not. `coverage.exclude` mirrors the negations in `packages/permissionless/package.json`
+`files` — that list *is* the definition of shipped code:
+
+| Excluded                                          | Why                                                        |
+| ------------------------------------------------- | ---------------------------------------------------------- |
+| `**/*.test.ts`, `**/*.bench.ts`, `**/setupTests.ts` | tests, not shipped                                        |
+| `**/*.test-d.ts`                                  | type tests: checked by `tsc`, never executed, so they would sit at 0 % |
+| `**/*.config.ts`                                  | `vitest.config.ts` itself                                  |
+| `**/permissionless-test/**`                       | the anvil rig                                              |
+| `**/_cjs/**`, `**/_esm/**`, `**/_types/**`        | build output                                               |
+
+Anything else under `packages/permissionless` is in the denominator, including
+`accounts/<x>/index.ts` and `errors/*.ts` — those are real modules that ship.
+
+The 18 `*.test-d.ts` files landed in 1.0 without a matching exclude and cost
+16.8 points of project coverage on their own (1,595 lines at 0 %), which is what
+`codecov.yml` now guards: `coverage.status.project.default` is `target: auto`
+with a `threshold` of 1 %, so a regression of that shape fails the check while
+rig noise does not.
+
+Codecov reads `coverage/lcov.info` (repo root — Vitest's `root` is the
+current working directory, not the config file's directory). To see the same
+numbers locally, add the reporters back:
+
+```bash
+CI=true ./node_modules/.bin/vitest run -c packages/permissionless/vitest.config.ts \
+  --coverage --coverage.reporter=text --coverage.reporter=lcov \
+  --pool=forks --no-file-parallelism
+```
 
 ## Fork mode
 

--- a/packages/permissionless/actions/erc20Paymaster/estimateCost.test.ts
+++ b/packages/permissionless/actions/erc20Paymaster/estimateCost.test.ts
@@ -1,25 +1,68 @@
-import type { Client } from "viem"
+import { Chain, type Client } from "viem"
 import { anvil } from "viem/chains"
 import { EntryPoint, type UserOperation } from "viem/erc4337"
 import { describe, expect, test } from "vitest"
 import { TokenQuoteNotFoundError } from "../../errors/erc20Paymaster"
 import { estimateCost } from "./estimateCost"
 
+const token = "0x0000000000000000000000000000000000000001"
+const entryPoint = { address: EntryPoint.addressV07, version: "0.7" } as const
+
+const client = <chain extends Chain.Chain | undefined>(
+    quotes: unknown[],
+    chain: chain
+): Pick<Client.Client<chain>, "chain" | "request"> => ({
+    chain,
+    // canned pimlico_getTokenQuotes result; the action only calls `request`
+    request: (async () => ({ quotes })) as unknown as Client.Client["request"]
+})
+
+const quote = {
+    paymaster: "0x0000000000000000000000000000000000000002",
+    token,
+    postOpGas: "0x186a0", // 100_000
+    exchangeRate: "0x1bc16d674ec80000", // 2e18
+    exchangeRateNativeToUsd: "0x6f05b59d3b20000" // 5e17
+}
+
+const userOperation = {
+    callGasLimit: 100_000n,
+    verificationGasLimit: 100_000n,
+    preVerificationGas: 50_000n,
+    maxFeePerGas: 2n
+} as UserOperation.UserOperation<"0.7">
+
 describe("estimateCost", () => {
     test("rejects with TokenQuoteNotFoundError when no quote is returned", async () => {
-        const client: Pick<Client.Client<typeof anvil>, "chain" | "request"> = {
-            chain: anvil,
-            // canned pimlico_getTokenQuotes result; the action only calls `request`
-            request: (async () => ({
-                quotes: []
-            })) as unknown as Client.Client["request"]
-        }
         await expect(
-            estimateCost(client, {
-                entryPoint: { address: EntryPoint.addressV07, version: "0.7" },
-                token: "0x0000000000000000000000000000000000000001",
+            estimateCost(client([], anvil), {
+                entryPoint,
+                token,
                 userOperation: {} as UserOperation.UserOperation<"0.7">
             })
         ).rejects.toThrow(TokenQuoteNotFoundError)
+    })
+
+    test("rejects when neither the client nor the call carries a chain", async () => {
+        await expect(
+            estimateCost(client([], undefined), {
+                chain: undefined,
+                entryPoint,
+                token,
+                userOperation
+            })
+        ).rejects.toThrow(Chain.NotFoundError)
+    })
+
+    test("prices the prefund plus postOpGas at the quoted rates", async () => {
+        // (100_000 + 100_000 + 50_000) * 2 maxFeePerGas + 100_000 postOpGas * 2
+        // = 700_000 wei, priced at the quote's two exchange rates
+        expect(
+            await estimateCost(client([quote], anvil), {
+                entryPoint,
+                token,
+                userOperation
+            })
+        ).toEqual({ costInToken: 1_400_000n, costInUsd: 350_000n })
     })
 })

--- a/packages/permissionless/actions/erc7579/isModuleInstalled.test.ts
+++ b/packages/permissionless/actions/erc7579/isModuleInstalled.test.ts
@@ -1,5 +1,6 @@
-import { AbiParameters, Address } from "viem/utils"
-import { describe, expect } from "vitest"
+import { ContractError } from "viem"
+import { AbiFunction, AbiParameters, Address } from "viem/utils"
+import { describe, expect, test } from "vitest"
 import { testWithRpc } from "../../../permissionless-test/src/testWithRpc"
 import { getCoreSmartAccounts } from "../../../permissionless-test/src/utils"
 import { erc7579Actions } from "../../clients/decorators/erc7579"
@@ -70,3 +71,92 @@ describe.each(getCoreSmartAccounts())(
         )
     }
 )
+
+describe("isModuleInstalled on an undeployed account", () => {
+    const module = "0x4Fd8d57b94966982B62e9588C27B4171B55E8354"
+    const abi = AbiFunction.from(
+        "function isModuleInstalled(uint256, address, bytes) view returns (bool)"
+    )
+
+    const account = (publicClient: unknown) =>
+        ({
+            address: "0x0000000000000000000000000000000000000001",
+            client: publicClient,
+            getFactoryArgs: async () => ({
+                factory: "0x0000000000000000000000000000000000000002",
+                factoryData: "0xf00d"
+            })
+        }) as never
+
+    const reverts = () => {
+        throw new ContractError.ContractFunctionExecutionError(
+            new ContractError.ContractFunctionRevertedError({
+                abi: [abi],
+                functionName: "isModuleInstalled"
+            }),
+            { abi: [abi], functionName: "isModuleInstalled" }
+        )
+    }
+
+    test("falls back to a counterfactual eth_call with the factory args", async () => {
+        const calls: unknown[] = []
+        const client = {
+            request: () => {},
+            contract: { read: reverts },
+            call: async (parameters: unknown) => {
+                calls.push(parameters)
+                return { data: AbiFunction.encodeResult(abi, true) }
+            }
+        }
+
+        expect(
+            await isModuleInstalled({ account: account(client) } as never, {
+                type: "executor",
+                address: module.toLowerCase() as never,
+                context: "0x"
+            })
+        ).toBe(true)
+        expect(calls[0]).toEqual({
+            factory: "0x0000000000000000000000000000000000000002",
+            factoryData: "0xf00d",
+            to: "0x0000000000000000000000000000000000000001",
+            // the module address is checksummed before it is encoded
+            data: AbiFunction.encodeData(abi, [2n, module, "0x"])
+        })
+    })
+
+    test("throws ContractFunctionZeroDataError when the counterfactual call returns nothing", async () => {
+        const client = {
+            request: () => {},
+            contract: { read: reverts },
+            call: async () => ({})
+        }
+
+        await expect(
+            isModuleInstalled({ account: account(client) } as never, {
+                type: "executor",
+                address: module,
+                context: "0x"
+            })
+        ).rejects.toThrow(ContractError.ContractFunctionZeroDataError)
+    })
+
+    test("rethrows anything that is not a contract execution error", async () => {
+        const client = {
+            request: () => {},
+            contract: {
+                read: () => {
+                    throw new Error("transport down")
+                }
+            }
+        }
+
+        await expect(
+            isModuleInstalled({ account: account(client) } as never, {
+                type: "executor",
+                address: module,
+                context: "0x"
+            })
+        ).rejects.toThrow("transport down")
+    })
+})

--- a/packages/permissionless/actions/etherspot/getUserOperationGasPrice.test.ts
+++ b/packages/permissionless/actions/etherspot/getUserOperationGasPrice.test.ts
@@ -1,0 +1,20 @@
+import type { Client } from "viem"
+import { describe, expect, test } from "vitest"
+import { getUserOperationGasPrice } from "./getUserOperationGasPrice"
+
+describe("etherspot getUserOperationGasPrice", () => {
+    test("decodes skandha_getGasPrice into bigints", async () => {
+        const calls: string[] = []
+        const client: Pick<Client.Client, "request"> = {
+            request: (async ({ method }: { method: string }) => {
+                calls.push(method)
+                return { maxFeePerGas: "0x2", maxPriorityFeePerGas: "0x1" }
+            }) as unknown as Client.Client["request"]
+        }
+        expect(await getUserOperationGasPrice(client)).toEqual({
+            maxFeePerGas: 2n,
+            maxPriorityFeePerGas: 1n
+        })
+        expect(calls).toEqual(["skandha_getGasPrice"])
+    })
+})

--- a/packages/permissionless/actions/passkeyServer/passkeyServer.test.ts
+++ b/packages/permissionless/actions/passkeyServer/passkeyServer.test.ts
@@ -6,6 +6,7 @@ import {
     PasskeyAttestationUnsupportedError
 } from "../../errors/passkeyServer"
 import { getCredentials } from "./getCredentials"
+import { startAuthentication } from "./startAuthentication"
 import { startRegistration } from "./startRegistration"
 import { verifyAuthentication } from "./verifyAuthentication"
 import { verifyRegistration } from "./verifyRegistration"
@@ -93,5 +94,187 @@ describe("passkey server actions", () => {
                 context: undefined
             })
         ).rejects.toThrow(InvalidPasskeyServerResponseError)
+    })
+})
+
+describe("passkey server credential options", () => {
+    const options = {
+        attestation: "none",
+        authenticatorSelection: {
+            authenticatorAttachment: "platform",
+            requireResidentKey: true,
+            residentKey: "required",
+            userVerification: "required"
+        },
+        challenge: "AQID",
+        rp: { id: "pimlico.io", name: "Pimlico" },
+        timeout: 60_000,
+        user: { id: "BAUG", name: "alice", displayName: "Alice" }
+    }
+
+    test("startRegistration decodes the base64url challenge and user id", async () => {
+        const credentialOptions = await startRegistration(server(options))
+        expect(credentialOptions.challenge).toEqual(new Uint8Array([1, 2, 3]))
+        expect(credentialOptions.user).toEqual({
+            id: new Uint8Array([4, 5, 6]),
+            name: "alice",
+            displayName: "Alice"
+        })
+        expect(credentialOptions.extensions).toBeUndefined()
+        expect(credentialOptions.rp).toEqual(options.rp)
+        expect(credentialOptions.timeout).toBe(60_000)
+    })
+
+    test("startRegistration rejects every malformed field on its own", async () => {
+        const rejects = async (override: Record<string, unknown>) =>
+            expect(
+                startRegistration(server({ ...options, ...override }))
+            ).rejects.toThrow(InvalidPasskeyServerResponseError)
+
+        await rejects({ attestation: "sometimes" })
+        await rejects({ authenticatorSelection: { residentKey: "required" } })
+        await rejects({
+            authenticatorSelection: {
+                ...options.authenticatorSelection,
+                requireResidentKey: "yes"
+            }
+        })
+        await rejects({ challenge: 1 })
+        await rejects({ extensions: "none" })
+        await rejects({ extensions: { appid: 1 } })
+        await rejects({ extensions: { credProps: "yes" } })
+        await rejects({ rp: { id: "pimlico.io" } })
+        await rejects({ user: { id: "BAUG", name: "alice" } })
+    })
+
+    test("startRegistration passes through well-formed extensions", async () => {
+        const extensions = { appid: "pimlico.io", credProps: true }
+        const credentialOptions = await startRegistration(
+            server({ ...options, extensions })
+        )
+        expect(credentialOptions.extensions).toEqual(extensions)
+    })
+
+    test("startAuthentication returns the challenge as hex", async () => {
+        expect(
+            await startAuthentication(
+                server({
+                    challenge: "AQID",
+                    rpId: "pimlico.io",
+                    userVerification: "required",
+                    uuid: "uuid"
+                })
+            )
+        ).toEqual({
+            challenge: "0x010203",
+            rpId: "pimlico.io",
+            userVerification: "required",
+            uuid: "uuid"
+        })
+    })
+})
+
+describe("passkey server verification", () => {
+    const success = {
+        success: true,
+        id: "id",
+        publicKey: "0x01",
+        userName: "alice"
+    }
+    const capture = (response: unknown) => {
+        const params: unknown[] = []
+        const client: Pick<Client.Client, "request"> = {
+            request: (async ({ params: p }: { params: unknown[] }) => {
+                params.push(...p)
+                return response
+            }) as unknown as Client.Client["request"]
+        }
+        return { params, client }
+    }
+
+    test("verifyRegistration base64-encodes the attestation for the server", async () => {
+        const { params, client } = capture(success)
+        const credential = {
+            id: "id",
+            raw: {
+                ...raw,
+                rawId: new Uint8Array([251, 255]).buffer,
+                response: {
+                    clientDataJSON: bytes,
+                    attestationObject: new Uint8Array([251, 255]).buffer,
+                    getPublicKeyAlgorithm: () => -7,
+                    getAuthenticatorData: () => bytes,
+                    getTransports: () => ["internal"]
+                }
+            }
+        } as never
+
+        expect(
+            await verifyRegistration(client, { credential, context: {} })
+        ).toEqual(success)
+        expect(params[0]).toEqual({
+            id: "id",
+            // unpadded base64url: "+/8=" becomes "-_8"
+            rawId: "-_8",
+            response: {
+                clientDataJSON: "AQID",
+                attestationObject: "-_8=",
+                transports: ["internal"],
+                publicKeyAlgorithm: -7,
+                authenticatorData: "AQID"
+            },
+            authenticatorAttachment: "platform",
+            clientExtensionResults: {},
+            type: "public-key"
+        })
+    })
+
+    test("verifyRegistration surfaces a broken getPublicKeyAlgorithm", async () => {
+        const { client } = capture(success)
+        await expect(
+            verifyRegistration(client, {
+                credential: {
+                    id: "id",
+                    raw: {
+                        ...raw,
+                        response: {
+                            clientDataJSON: bytes,
+                            attestationObject: bytes,
+                            getPublicKeyAlgorithm: () => {
+                                throw new Error("no attestation")
+                            }
+                        }
+                    }
+                } as never,
+                context: {}
+            })
+        ).rejects.toThrow(PasskeyAttestationUnsupportedError)
+    })
+
+    test("verifyAuthentication forwards the uuid and an optional userHandle", async () => {
+        const { params, client } = capture(success)
+        expect(
+            await verifyAuthentication(client, {
+                raw: {
+                    ...raw,
+                    response: {
+                        clientDataJSON: bytes,
+                        authenticatorData: bytes,
+                        signature: bytes,
+                        userHandle: bytes
+                    }
+                },
+                uuid: "uuid"
+            } as never)
+        ).toEqual(success)
+        expect(params[0]).toMatchObject({
+            response: {
+                clientDataJSON: "AQID",
+                authenticatorData: "AQID",
+                signature: "AQID",
+                userHandle: "AQID"
+            }
+        })
+        expect(params[1]).toEqual({ uuid: "uuid" })
     })
 })

--- a/packages/permissionless/actions/smartAccount/writeContract.test.ts
+++ b/packages/permissionless/actions/smartAccount/writeContract.test.ts
@@ -1,0 +1,60 @@
+import type { Chain } from "viem"
+import type { BundlerClient, SmartAccount } from "viem/erc4337"
+import { Abi, AbiFunction } from "viem/utils"
+import { describe, expect, test } from "vitest"
+import { writeContract } from "./writeContract"
+
+const abi = Abi.from(["function transfer(address, uint256) returns (bool)"])
+const address = "0x0000000000000000000000000000000000000001"
+const to = "0x0000000000000000000000000000000000000002"
+
+const client = (sent: unknown[]) =>
+    ({
+        request: () => {},
+        // intercepts `getAction(client, sendTransaction, "sendTransaction")`
+        sendTransaction: async (parameters: unknown) => {
+            sent.push(parameters)
+            return "0xdeadbeef"
+        }
+    }) as unknown as BundlerClient.Client<
+        Chain.Chain | undefined,
+        SmartAccount.SmartAccount
+    >
+
+describe("writeContract", () => {
+    test("encodes the call and forwards it to sendTransaction", async () => {
+        const sent: unknown[] = []
+        const hash = await writeContract(client(sent), {
+            abi,
+            address,
+            functionName: "transfer",
+            args: [to, 1n],
+            value: 2n
+        })
+
+        expect(hash).toBe("0xdeadbeef")
+        expect(sent[0]).toEqual({
+            to: address,
+            value: 2n,
+            data: AbiFunction.encodeData(AbiFunction.fromAbi(abi, "transfer"), [
+                to,
+                1n
+            ])
+        })
+    })
+
+    test("appends dataSuffix without its 0x prefix", async () => {
+        const sent: unknown[] = []
+        await writeContract(client(sent), {
+            abi,
+            address,
+            functionName: "transfer",
+            args: [to, 1n],
+            dataSuffix: "0xc0ffee"
+        })
+
+        expect((sent[0] as { data: string }).data).toBe(
+            `${AbiFunction.encodeData(AbiFunction.fromAbi(abi, "transfer"), [to, 1n])}c0ffee`
+        )
+    })
+})

--- a/packages/permissionless/clients/decorators/pimlico.test.ts
+++ b/packages/permissionless/clients/decorators/pimlico.test.ts
@@ -1,0 +1,128 @@
+import type { Client } from "viem"
+import { anvil } from "viem/chains"
+import { EntryPoint, type UserOperation } from "viem/erc4337"
+import { describe, expect, test } from "vitest"
+import { pimlicoActions } from "./pimlico"
+
+const entryPoint = { address: EntryPoint.addressV07, version: "0.7" } as const
+const token = "0x0000000000000000000000000000000000000001"
+const paymaster = "0x0000000000000000000000000000000000000002"
+
+const userOperation = {
+    sender: "0x0000000000000000000000000000000000000003",
+    nonce: 0n,
+    callData: "0x",
+    callGasLimit: 100_000n,
+    verificationGasLimit: 100_000n,
+    preVerificationGas: 50_000n,
+    maxFeePerGas: 2n,
+    maxPriorityFeePerGas: 1n,
+    signature: "0x"
+} as UserOperation.UserOperation<"0.7">
+
+const quote = {
+    paymaster,
+    token,
+    postOpGas: "0x186a0", // 100_000
+    exchangeRate: "0xde0b6b3a7640000", // 1e18
+    exchangeRateNativeToUsd: "0x1bc16d674ec80000" // 2e18
+}
+
+const actions = (results: Record<string, unknown>) => {
+    const calls: { method: string; params: unknown[] }[] = []
+    const client = {
+        chain: anvil,
+        request: (async (call: { method: string; params: unknown[] }) => {
+            calls.push(call)
+            return results[call.method]
+        }) as unknown as Client.Client["request"]
+    }
+    return { calls, ...pimlicoActions({ entryPoint })(client) }
+}
+
+describe("pimlicoActions", () => {
+    test("getUserOperationGasPrice decodes all three tiers", async () => {
+        const tier = { maxFeePerGas: "0x2", maxPriorityFeePerGas: "0x1" }
+        const { getUserOperationGasPrice } = actions({
+            pimlico_getUserOperationGasPrice: {
+                slow: tier,
+                standard: tier,
+                fast: tier
+            }
+        })
+        expect(await getUserOperationGasPrice()).toEqual({
+            slow: { maxFeePerGas: 2n, maxPriorityFeePerGas: 1n },
+            standard: { maxFeePerGas: 2n, maxPriorityFeePerGas: 1n },
+            fast: { maxFeePerGas: 2n, maxPriorityFeePerGas: 1n }
+        })
+    })
+
+    test("getUserOperationStatus forwards the hash", async () => {
+        const status = { status: "included", transactionHash: "0xabc" }
+        const { calls, getUserOperationStatus } = actions({
+            pimlico_getUserOperationStatus: status
+        })
+        expect(await getUserOperationStatus({ hash: "0xdead" })).toEqual(status)
+        expect(calls[0]).toEqual({
+            method: "pimlico_getUserOperationStatus",
+            params: ["0xdead"]
+        })
+    })
+
+    test("sponsorUserOperation injects the client's entryPoint address", async () => {
+        const { calls, sponsorUserOperation } = actions({
+            pm_sponsorUserOperation: {
+                callGasLimit: "0x1",
+                verificationGasLimit: "0x2",
+                preVerificationGas: "0x3",
+                paymaster,
+                paymasterVerificationGasLimit: "0x4",
+                paymasterPostOpGasLimit: "0x5",
+                paymasterData: "0x"
+            }
+        })
+        const sponsored = await sponsorUserOperation({ userOperation })
+        expect(sponsored.paymaster).toBe(paymaster)
+        expect(sponsored.callGasLimit).toBe(1n)
+        expect(calls[0]?.params[1]).toBe(entryPoint.address)
+    })
+
+    test("validateSponsorshipPolicies injects the entryPoint address", async () => {
+        const { calls, validateSponsorshipPolicies } = actions({
+            pm_validateSponsorshipPolicies: []
+        })
+        await validateSponsorshipPolicies({
+            userOperation,
+            sponsorshipPolicyIds: ["sp_shiny_puma"]
+        })
+        expect(calls[0]?.params[1]).toBe(entryPoint.address)
+        expect(calls[0]?.params[2]).toEqual(["sp_shiny_puma"])
+    })
+
+    test("getTokenQuotes injects the entryPoint address and the client's chain", async () => {
+        const { calls, getTokenQuotes } = actions({
+            pimlico_getTokenQuotes: { quotes: [quote] }
+        })
+        const [decoded] = await getTokenQuotes({ tokens: [token] })
+        expect(decoded?.postOpGas).toBe(100_000n)
+        expect(decoded?.exchangeRate).toBe(10n ** 18n)
+        expect(calls[0]).toEqual({
+            method: "pimlico_getTokenQuotes",
+            params: [{ tokens: [token] }, entryPoint.address, "0x7a69"]
+        })
+    })
+
+    test("estimateErc20PaymasterCost prices the userOperation with the quote", async () => {
+        const { estimateErc20PaymasterCost } = actions({
+            pimlico_getTokenQuotes: { quotes: [quote] }
+        })
+        // (100_000 + 100_000 + 50_000) * 2 maxFeePerGas + 100_000 postOpGas * 2
+        const maxCostInWei = 700_000n
+        expect(
+            await estimateErc20PaymasterCost({ userOperation, token })
+        ).toEqual({
+            costInToken: maxCostInWei,
+            costInUsd: maxCostInWei * 2n
+        })
+    })
+})

--- a/packages/permissionless/clients/passkeyServer/index.test.ts
+++ b/packages/permissionless/clients/passkeyServer/index.test.ts
@@ -1,0 +1,84 @@
+import { custom } from "viem"
+import { describe, expect, test } from "vitest"
+import {
+    InvalidPasskeyCredentialError,
+    InvalidPasskeyServerResponseError
+} from "../../errors/passkeyServer"
+import * as PasskeyServerClient from "./index"
+
+const bytes = new Uint8Array([1, 2, 3]).buffer
+const calls: string[] = []
+const client = PasskeyServerClient.create({
+    transport: custom({
+        request: async ({ method }: { method: string }) => {
+            calls.push(method)
+            if (method === "pks_getCredentials")
+                return [{ id: "id", publicKey: "0x01" }]
+            if (method === "pks_startAuthentication")
+                return {
+                    challenge: "AQID",
+                    rpId: "pimlico.io",
+                    uuid: "uuid"
+                }
+            return {}
+        }
+    })
+})
+
+describe("PasskeyServerClient", () => {
+    test("carries the passkey server defaults", () => {
+        expect(client.key).toBe("public")
+        expect(client.name).toBe("Passkey Server Client")
+        expect(client.type).toBe("passkeyServerClient")
+    })
+
+    test("getCredentials and startAuthentication reach the server", async () => {
+        expect(await client.getCredentials({})).toEqual([
+            { id: "id", publicKey: "0x01" }
+        ])
+        expect(await client.startAuthentication()).toEqual({
+            challenge: "0x010203",
+            rpId: "pimlico.io",
+            userVerification: undefined,
+            uuid: "uuid"
+        })
+        expect(calls).toEqual(["pks_getCredentials", "pks_startAuthentication"])
+    })
+
+    test("the decorated actions surface their own validation errors", async () => {
+        await expect(client.startRegistration({})).rejects.toThrow(
+            InvalidPasskeyServerResponseError
+        )
+        await expect(
+            client.verifyAuthentication({
+                raw: {
+                    id: "id",
+                    rawId: bytes,
+                    authenticatorAttachment: "platform",
+                    response: { clientDataJSON: bytes },
+                    getClientExtensionResults: () => ({}),
+                    type: "public-key"
+                },
+                uuid: "uuid"
+            })
+        ).rejects.toThrow(InvalidPasskeyCredentialError)
+        await expect(
+            client.verifyRegistration({
+                credential: {
+                    id: "id",
+                    raw: {
+                        rawId: bytes,
+                        response: {
+                            clientDataJSON: bytes,
+                            attestationObject: bytes
+                        },
+                        authenticatorAttachment: "platform",
+                        getClientExtensionResults: () => ({}),
+                        type: "public-key"
+                    }
+                } as never,
+                context: {}
+            })
+        ).rejects.toThrow(InvalidPasskeyServerResponseError)
+    })
+})

--- a/packages/permissionless/utils/toOwner.test.ts
+++ b/packages/permissionless/utils/toOwner.test.ts
@@ -1,3 +1,4 @@
+import { Account } from "viem"
 import { describe, expect, test } from "vitest"
 import {
     OwnerAddressRequiredError,
@@ -21,5 +22,55 @@ describe("toOwner", () => {
         expect(() => owner.sign({ hash: "0x" })).toThrow(
             OwnerSignUnsupportedError
         )
+    })
+
+    test("local accounts are returned untouched", async () => {
+        const account = Account.fromPrivateKey(`0x${"1".padStart(64, "0")}`)
+        expect(await toOwner({ owner: account })).toBe(account)
+    })
+
+    test("falls back to eth_accounts when eth_requestAccounts is unavailable", async () => {
+        const methods: string[] = []
+        const owner = await toOwner({
+            owner: {
+                request: async ({ method }: { method: string }) => {
+                    methods.push(method)
+                    if (method === "eth_requestAccounts")
+                        throw new Error("unsupported")
+                    return [address]
+                }
+            }
+        })
+        expect(methods).toEqual(["eth_requestAccounts", "eth_accounts"])
+        expect(owner.address).toBe(address)
+    })
+
+    test("signing is delegated to the wallet client", async () => {
+        const signed: unknown[] = []
+        const walletClient = {
+            account: { address },
+            signMessage: async (parameters: unknown) => {
+                signed.push(parameters)
+                return "0xmessage"
+            },
+            typedData: {
+                sign: async (parameters: unknown) => {
+                    signed.push(parameters)
+                    return "0xtypedData"
+                }
+            }
+        }
+        const owner = await toOwner({ owner: walletClient as never })
+
+        expect(owner.address).toBe(address)
+        expect(await owner.signMessage({ message: "hello" })).toBe("0xmessage")
+        const typedData = {
+            domain: { name: "Pimlico" },
+            types: { Foo: [{ name: "bar", type: "uint256" }] },
+            primaryType: "Foo",
+            message: { bar: 1n }
+        } as never
+        expect(await owner.signTypedData(typedData)).toBe("0xtypedData")
+        expect(signed).toEqual([{ message: "hello" }, typedData])
     })
 })

--- a/packages/permissionless/vitest.config.ts
+++ b/packages/permissionless/vitest.config.ts
@@ -41,8 +41,14 @@ export default defineConfig({
             provider: "v8",
             reporter: process.env.CI ? ["lcov"] : ["text", "json", "html"],
             include: ["**/permissionless/**"],
+            // package.json `files` defines shipped code; everything it
+            // negates is out of the denominator, the build output with it.
             exclude: [
                 "**/*.test.ts",
+                "**/*.test-d.ts",
+                "**/*.bench.ts",
+                "**/setupTests.ts",
+                "**/*.config.ts",
                 "**/permissionless-test/**",
                 "**/_cjs/**",
                 "**/_esm/**",


### PR DESCRIPTION
Ticket: **Coverage: 78.43% (main) → 69.86% (integration) — restore and pin**
(`~/.wayfinder/permissionless.js/worktree/permissionless-v-1/issues/37-coverage-regression.md`)

The −8.57 % was accounting, not untested code: the 18 `*.test-d.ts` files added by ticket 20 are type-only, never execute, and sat in the denominator at 0 % (1,595 lines), and `vitest.config.ts` counted itself (70). Excluding them turns the *same* Codecov report for `1f4f696` into **87.61 %**, against **78.78 %** for `main` on the same accounting — shipped-code coverage went up 8.8 points across the 1.0 port, it never went down.

Exact decomposition of `main` 78.43 % → integration 69.86 % (Codecov, shipped-only chain):

| step | % | Δ |
| --- | --- | --- |
| `main` @ `e9caa7f`, `vitest.config.ts` excluded | 78.78 | — |
| drop the 43 files 1.0 deletes (they were 80.64 % covered) | 75.56 | −3.22 |
| the 62 surviving files, as 1.0 has them | 86.38 | +10.82 |
| add the 46 new 1.0 files (88.67 % covered) | 87.61 | +1.23 |
| count `vitest.config.ts` | 86.68 | −0.93 |
| count the 18 `*.test-d.ts` | **69.86** | **−16.82** |

## What changed

- `vitest.config.ts` — coverage `exclude` now mirrors the negations in `package.json` `files`, which is the definition of shipped code: `**/*.test-d.ts`, `**/*.bench.ts`, `**/setupTests.ts`, `**/*.config.ts` join `**/*.test.ts`. No real module leaves the denominator: `accounts/<x>/index.ts` and `errors/*.ts` stay counted.
- 27 new tests across 8 files (4 new) over shipped code the anvil rig never reaches — `writeContract` (3.4 % → covered), `pimlicoActions` (every action's entryPoint injection), `PasskeyServerClient` + its decorator, `startRegistration`/`startAuthentication`/`verify*` encodings, `estimateCost`'s pricing formula, etherspot `getUserOperationGasPrice`, `toOwner`'s provider/wallet-client paths, and `isModuleInstalled`'s counterfactual `eth_call` fallback for undeployed accounts.
- `codecov.yml` at the repo root — `coverage.status.project.default`: `target: auto`, `threshold: 1%` (validated against `https://codecov.io/validate`). A drop of this shape fails the check; rig noise does not.
- `docs/testing/06-ci-and-running.md` — a "Coverage accounting" section: what is excluded and why, where the lcov lands, how to reproduce the CI numbers locally.

## Verified

Local, anvil **1.8.1**, `CI=true vitest run --coverage --pool=forks --no-file-parallelism`:

| | files | lines | project |
| --- | --- | --- | --- |
| `main` @ `e9caa7f` (0.x, anvil 1.5.1) | 109 | 9,004 | 80.83 % (81.19 % shipped-only) |
| this branch's base `1f4f696` | 131 | 8,219 | 71.80 % (90.04 % shipped-only) |
| **this PR** | **112** | **6,554** | **93.71 %** (branches 83.09 %) |

Suite: **81 files, 979 passed, 1,033 skipped, 0 failed**, 450 s (`main`: 33 files, 757 passed, 966 skipped; base: 77 files, 952 passed).

`bun lint` clean · `bun run typecheck` (TS 7) clean · `bun run test:types` 18 files / 100 tests, no type errors.

Least-covered shipped files after this PR:

| file | uncovered | lines | % |
| --- | --- | --- | --- |
| `accounts/safe/from.ts` | 112 | 1230 | 90.89 % |
| `accounts/safe/signUserOperation.ts` | 58 | 195 | 70.26 % |
| `actions/erc20Paymaster/prepareUserOperation.ts` | 46 | 238 | 80.67 % |
| `accounts/kernel/from.ts` | 33 | 328 | 89.94 % |
| `accounts/kernel/utils/signHash.ts` | 18 | 64 | 71.88 % |
| `accounts/light/from.ts` | 17 | 153 | 88.89 % |
| `accounts/etherspot/index.ts` | 14 | 133 | 89.47 % |
| `accounts/trust/index.ts` | 12 | 142 | 91.55 % |
| `accounts/nexus/index.ts` | 11 | 156 | 92.95 % |
| `accounts/thirdweb/index.ts` | 11 | 176 | 93.75 % |

CI on this PR: all seven Actions checks green (E2E-Coverage 4m11s), **`codecov/project` green at 91.34 % (+21.48 % vs `1f4f696`)**, `codecov/patch` green. CI's denominator is 6,554 lines, identical to local; it hits 5,987 of them against 6,142 locally.

The 1.0 baseline is 91.34 % on CI / 93.71 % locally on this branch — so the `auto` target pins that, not the 78 % the ticket asked to restore.

Deliberately left: the same counterfactual-read fallback in `accountId`/`supportsModule`/`supportsExecutionMode` (pinned once in `isModuleInstalled` — three more copies would be line-chasing), and the per-version branches in `accounts/safe/from.ts`, `accounts/kernel/from.ts` and `accounts/safe/signUserOperation.ts`, which need new rig matrix cells rather than unit tests. The 1,033 skipped tests are matrix cells for account × entryPoint combinations that do not exist (every `skipIf` predicate — `supportsEntryPointV0{6,7,8}`, `isEip1271Compliant`, `getErc7579SmartAccountClient` — has at least one satisfying account), so they leave no shipped branch permanently unexecuted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEsZmQJiyF8AAGAc1VYbLE
